### PR TITLE
feat: express #57 seed data 생성, admin model 추가

### DIFF
--- a/munetic_admin/Dockerfile
+++ b/munetic_admin/Dockerfile
@@ -2,6 +2,6 @@ FROM node:16
 RUN mkdir munetic_admin
 WORKDIR /munetic_admin
 COPY . .
-RUN npm i esbuild-linux-arm64
+RUN npm i esbuild
 RUN npm i
 CMD [ "npm", "run", "dev" ]

--- a/munetic_app/Dockerfile
+++ b/munetic_app/Dockerfile
@@ -2,6 +2,6 @@ FROM node:16
 RUN mkdir munetic_app
 WORKDIR /munetic_app
 COPY . .
-RUN npm i esbuild-linux-arm64
+RUN npm i esbuild
 RUN npm i
 CMD [ "npm", "run", "dev" ]

--- a/munetic_database/my.cnf
+++ b/munetic_database/my.cnf
@@ -33,3 +33,9 @@ skip-name-resolve
 !includedir /etc/mysql/conf.d/
 lower_case_table_names  = 1
 # For not to discern lower cases and upper cases
+
+[client]
+default-character-set = utf8
+
+[mysql]
+default-character-set = utf8

--- a/munetic_express/.sequelizerc
+++ b/munetic_express/.sequelizerc
@@ -1,0 +1,11 @@
+require('ts-node').register({
+  /* options */
+});
+const path = require('path');
+
+module.exports = {
+  config: path.resolve('./src/config', 'config.ts'),
+  'migrations-path': path.resolve('./src', 'migrations'),
+  'models-path': path.resolve('./src', 'models'),
+  'seeders-path': path.resolve('./src', 'seeders'),
+};

--- a/munetic_express/src/config/config.ts
+++ b/munetic_express/src/config/config.ts
@@ -1,16 +1,15 @@
 import * as dotenv from 'dotenv';
 dotenv.config();
 
-export const config = {
-  development: {
-    db: {
-      host: process.env.DB_HOST,
-      port: parseInt(process.env.DB_PORT!, 10),
-      username: process.env.DB_USERNAME,
-      password: process.env.DB_PASSWORD,
-      database: process.env.DB_NAME,
-    },
-  },
+const development = {
+  host: process.env.DB_HOST,
+  port: parseInt(process.env.DB_PORT!, 10),
+  username: process.env.DB_USERNAME,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+  dialect: 'mariadb',
   // test: {},
   // production: {},
 };
+
+module.exports = { development };

--- a/munetic_express/src/models/admin.ts
+++ b/munetic_express/src/models/admin.ts
@@ -1,0 +1,45 @@
+import { sequelize } from './index';
+import { Sequelize, DataTypes, Model, Optional } from 'sequelize';
+
+interface adminAttributes {
+  id: number;
+  login_email: string | null;
+  login_password: string | null;
+}
+
+type adminCreationAttributes = Optional<
+  adminAttributes,
+  'id' | 'login_email' | 'login_password'
+>;
+
+export class Admin
+  extends Model<adminAttributes, adminCreationAttributes>
+  implements adminAttributes
+{
+  public id!: number;
+  public login_email!: string | null;
+  public login_password!: string | null;
+
+  static initModel(sequelize: Sequelize): typeof Admin {
+    return Admin.init(
+      {
+        id: {
+          allowNull: false,
+          autoIncrement: true,
+          type: DataTypes.INTEGER,
+          primaryKey: true,
+        },
+        login_email: {
+          allowNull: true,
+          type: DataTypes.STRING(80),
+          unique: true,
+        },
+        login_password: {
+          allowNull: true,
+          type: DataTypes.STRING(60),
+        },
+      },
+      { tableName: 'Admin', sequelize },
+    );
+  }
+}

--- a/munetic_express/src/models/index.ts
+++ b/munetic_express/src/models/index.ts
@@ -1,18 +1,12 @@
 import { Sequelize } from 'sequelize';
-import { config } from '../config/config';
+import { Admin } from './admin';
 import { Category } from './category';
 import { Lesson } from './lesson';
 import { User } from './user';
 
-const { db } = config.development;
+const { development } = require('../config/config');
 
-const { host, port, database, username, password } = db as {
-  host: string;
-  port: number;
-  database: string;
-  username: string;
-  password: string;
-};
+const { host, port, database, username, password } = development;
 
 export const sequelize = new Sequelize(database!, username!, password, {
   host,
@@ -41,15 +35,20 @@ export function Models() {
   Category.initModel(sequelize);
   User.initModel(sequelize);
   Lesson.initModel(sequelize);
+  Admin.initModel(sequelize);
 
-  Category.hasMany(Lesson);
+  Category.hasMany(Lesson, {
+    foreignKey: 'category_id',
+  });
   Lesson.belongsTo(Category, {
     foreignKey: {
-      name: 'category_name',
+      name: 'category_id',
       allowNull: false,
     },
   });
-  User.hasMany(Lesson);
+  User.hasMany(Lesson, {
+    foreignKey: 'tutor_id',
+  });
   Lesson.belongsTo(User, {
     foreignKey: {
       name: 'tutor_id',

--- a/munetic_express/src/models/user.ts
+++ b/munetic_express/src/models/user.ts
@@ -1,40 +1,3 @@
-/**
- * @swagger
- * components:
- *  schemas:
- *   User:
- *    type: object
- *    properties:
- *     id:
- *      type: number
- *     type:
- *      type: string
- *     login_id:
- *      type: string
- *     login_password:
- *      type: string
- *     nickname:
- *      type: string
- *     name:
- *      type: string
- *     name_public:
- *      type: boolean
- *     email:
- *      type: string
- *     phone_number:
- *      type: string
- *     image_url:
- *      type: string
- *     introduction:
- *      type: string
- *     created_at:
- *      type: date
- *     updated_at:
- *      type: date
- *     deleted_at:
- *      type: date
- */
-
 import { Model, Optional, Sequelize, DataTypes } from 'sequelize';
 
 enum ACCOUNT {
@@ -52,6 +15,7 @@ interface userAttributes {
   name_public: boolean | null;
   email: string | null;
   phone_number: string | null;
+  phone_public: boolean | null;
   image_url: string | null;
   introduction: string | null;
 }
@@ -65,6 +29,7 @@ export type userCreationAttributes = Optional<
   | 'name_public'
   | 'email'
   | 'phone_number'
+  | 'phone_public'
   | 'image_url'
   | 'introduction'
 >;
@@ -82,6 +47,7 @@ export class User
   public name_public!: boolean | null;
   public email!: string | null;
   public phone_number!: string | null;
+  public phone_public!: boolean | null;
   public image_url!: string | null;
   public introduction!: string | null;
 
@@ -99,43 +65,47 @@ export class User
           type: DataTypes.ENUM('STUDENT', 'TUTOR'),
         },
         login_id: {
-          allowNull: false,
-          type: DataTypes.STRING(30),
-          unique: true,
-        },
-        login_password: {
-          allowNull: false,
-          type: DataTypes.STRING(60),
-        },
-        nickname: {
           allowNull: true,
           type: DataTypes.STRING(30),
           unique: true,
         },
-        name: {
+        login_password: {
+          allowNull: true,
+          type: DataTypes.STRING(60),
+        },
+        nickname: {
           allowNull: false,
+          type: DataTypes.STRING(30),
+          unique: true,
+        },
+        name: {
+          allowNull: true,
           type: DataTypes.STRING(50),
         },
         name_public: {
-          allowNull: false,
+          allowNull: true,
           type: DataTypes.BOOLEAN,
         },
         email: {
-          allowNull: false,
+          allowNull: true,
           type: DataTypes.STRING(128),
           unique: true,
         },
         phone_number: {
-          allowNull: false,
+          allowNull: true,
           type: DataTypes.STRING(20),
           unique: true,
         },
+        phone_public: {
+          allowNull: true,
+          type: DataTypes.BOOLEAN,
+        },
         image_url: {
-          allowNull: false,
+          allowNull: true,
           type: DataTypes.STRING(256),
         },
         introduction: {
-          allowNull: false,
+          allowNull: true,
           type: DataTypes.STRING(8192),
         },
       },

--- a/munetic_express/src/seeders/20211217081856-User.js
+++ b/munetic_express/src/seeders/20211217081856-User.js
@@ -1,0 +1,60 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkInsert('User', [
+      {
+        type: 'STUDENT',
+        login_id: '42kunlee',
+        login_password:
+          '$2b$10$fO/O6fF5w1HDkXNab8AMBOYE/9ByW8/sjIeXpQONQgJxkegxdFDIq',
+        nickname: 'kunlee',
+        name: '쿠운리',
+        name_public: true,
+        email: '42.kunlee@gmail.com',
+        phone_number: '010-1234-1234',
+        phone_public: true,
+        image_url: '../../munetic_app/public/img/testImg.png',
+        introduction: '안녕하세요. kunlee입니다. test data입니다.',
+        createdAt: Sequelize.fn('now'),
+        updatedAt: Sequelize.fn('now'),
+      },
+      {
+        type: 'TUTOR',
+        login_id: '42jolim',
+        login_password:
+          '$2b$10$fO/O6fF5w1HDkXNab8AMBOYE/9ByW8/sjIeXpQONQgJxkegxdFDIq',
+        nickname: 'jolim',
+        name: '조올림',
+        name_public: true,
+        email: '42.jolim@gmail.com',
+        phone_number: '010-5678-5678',
+        phone_public: false,
+        image_url: '../../munetic_app/public/img/testImg.png',
+        introduction: '안녕하세요. jolim입니다. test data입니다.',
+        createdAt: Sequelize.fn('now'),
+        updatedAt: Sequelize.fn('now'),
+      },
+      {
+        type: 'STUDENT',
+        login_id: '42chaepark',
+        login_password:
+          '$2b$10$fO/O6fF5w1HDkXNab8AMBOYE/9ByW8/sjIeXpQONQgJxkegxdFDIq',
+        nickname: 'chaepark',
+        name: '채애팤',
+        name_public: false,
+        email: '42.chaepark@gmail.com',
+        phone_number: '010-1234-5678',
+        phone_public: true,
+        image_url: '../../munetic_app/public/img/testImg.png',
+        introduction: '안녕하세요. chaepark입니다. test data입니다.',
+        createdAt: Sequelize.fn('now'),
+        updatedAt: Sequelize.fn('now'),
+      },
+    ]);
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('User', null, {});
+  },
+};

--- a/munetic_express/src/seeders/20211217154054-Admin.js
+++ b/munetic_express/src/seeders/20211217154054-Admin.js
@@ -1,0 +1,33 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkInsert('Admin', [
+      {
+        login_email: 'adminKunlee@munetic.com',
+        login_password:
+          '$2b$10$fO/O6fF5w1HDkXNab8AMBOYE/9ByW8/sjIeXpQONQgJxkegxdFDIq',
+        createdAt: Sequelize.fn('now'),
+        updatedAt: Sequelize.fn('now'),
+      },
+      {
+        login_email: 'adminJolim@munetic.com',
+        login_password:
+          '$2b$10$fO/O6fF5w1HDkXNab8AMBOYE/9ByW8/sjIeXpQONQgJxkegxdFDIq',
+        createdAt: Sequelize.fn('now'),
+        updatedAt: Sequelize.fn('now'),
+      },
+      {
+        login_email: 'adminChaepark@munetic.com',
+        login_password:
+          '$2b$10$fO/O6fF5w1HDkXNab8AMBOYE/9ByW8/sjIeXpQONQgJxkegxdFDIq',
+        createdAt: Sequelize.fn('now'),
+        updatedAt: Sequelize.fn('now'),
+      },
+    ]);
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('Admin', null, {});
+  },
+};

--- a/munetic_express/src/seeders/20211217154104-Category.js
+++ b/munetic_express/src/seeders/20211217154104-Category.js
@@ -1,0 +1,42 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkInsert('Category', [
+      {
+        name: '기타',
+        createdAt: Sequelize.fn('now'),
+        updatedAt: Sequelize.fn('now'),
+      },
+      {
+        name: '바이올린',
+        createdAt: Sequelize.fn('now'),
+        updatedAt: Sequelize.fn('now'),
+      },
+      {
+        name: '드럼',
+        createdAt: Sequelize.fn('now'),
+        updatedAt: Sequelize.fn('now'),
+      },
+      {
+        name: '피아노',
+        createdAt: Sequelize.fn('now'),
+        updatedAt: Sequelize.fn('now'),
+      },
+      {
+        name: '하프',
+        createdAt: Sequelize.fn('now'),
+        updatedAt: Sequelize.fn('now'),
+      },
+      {
+        name: '첼로',
+        createdAt: Sequelize.fn('now'),
+        updatedAt: Sequelize.fn('now'),
+      },
+    ]);
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('Category', null, {});
+  },
+};

--- a/munetic_express/src/seeders/20211218124842-Lesson.js
+++ b/munetic_express/src/seeders/20211218124842-Lesson.js
@@ -1,0 +1,53 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkInsert('Lesson', [
+      {
+        tutor_id: 2,
+        category_id: 1,
+        title: '지금까지 이런 기타 레슨은 없었다.',
+        price: 100000,
+        gender: 'Male',
+        location: '서울시',
+        age: 30,
+        minute_per_lesson: 60,
+        content: '더 이상 설명이 필요 없습니다. 믿고 따라오세요.',
+        createdAt: Sequelize.fn('now'),
+        updatedAt: Sequelize.fn('now'),
+      },
+      {
+        tutor_id: 2,
+        category_id: 2,
+        title: '기타만 잘 치는 줄 아셨죠? 바이올린도 합니다.',
+        price: 200000,
+        gender: 'Male',
+        location: '서울시',
+        age: 30,
+        minute_per_lesson: 80,
+        content:
+          '헨리도 저한테 바이올린 배웠습니다. 더 이상 설명이 필요 없습니다. 믿고 따라오세요.',
+        createdAt: Sequelize.fn('now'),
+        updatedAt: Sequelize.fn('now'),
+      },
+      {
+        tutor_id: 2,
+        category_id: 3,
+        title: '죄송합니다. 드럼도 가르쳐드립니다.',
+        price: 50000,
+        gender: 'Male',
+        location: '경기도',
+        age: 30,
+        minute_per_lesson: 40,
+        content:
+          '드럼드럼드럼드럼드럼드럼 더 이상 설명이 필요 없습니다. 믿고 따라오세요.',
+        createdAt: Sequelize.fn('now'),
+        updatedAt: Sequelize.fn('now'),
+      },
+    ]);
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('Lesson', null, {});
+  },
+};


### PR DESCRIPTION
### 개요
seed data 생성, admin model 추가
### 작업 사항
- admin, app Dockerfile : npm i esbuild 로 수정
- mariadb 한글 ???현상 해결 : munetic_database/my.cnf 수정 [client], [mysql] default-character-set = utf8 추가
- sequelize 시작 루트를 ./src 로 설정하기 위해 .sequelizerc 생성 
- config.ts 형식 export -> module.export 로 수정
- admin ERD 생성에 따른  admin model 추가
- user ERD 수정에 따른 phone_public 컬럼 추가 및 기존 컬럼 null 특성 관련 오류 수정
- seeders 폴더 내 user, lesson, category, admin seed data 추가
### 변경점
- seed data를 통해 api 작업을 테스트 할 수 있을 것
### 목적
실제 데이터가 없는 상태에서 더미 데이터를 한번에 입력해줌으로서 작업을 용이하게 하기 위함
### 스크린샷 (optional)
