### PR TITLE
feature: CI/CD #51 change to less memory required

### DIFF
--- a/munetic_admin/package.json
+++ b/munetic_admin/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
-    "react-router-dom": "^6.0.2"
+    "react-router-dom": "^6.0.2",
+    "serve": "^13.0.2"
   },
   "devDependencies": {
     "@types/react": "^17.0.0",

--- a/munetic_app/package.json
+++ b/munetic_app/package.json
@@ -17,6 +17,7 @@
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
     "react-router-dom": "^6.0.2",
+    "serve": "^13.0.2",
     "styled-components": "^5.3.3",
     "styled-reset": "^4.3.4"
   },

--- a/munetic_express/package.json
+++ b/munetic_express/package.json
@@ -4,7 +4,8 @@
   "description": "backend server for the project munetic",
   "main": "index.js",
   "scripts": {
-    "start": "tsc-watch --onSuccess \"ts-node dist/app.js\""
+    "test": "tsc-watch --onSuccess \"ts-node dist/app.js\"",
+    "serve": "tsc && node dist/app.js"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
### 개요
도커 컴포즈에서 ts파일을 바로 띄우니 메모리를 엄청나게 잡아먹어서 컴파일
후 dist를 실행하는 방식으로 바꾸었습니다.

### 작업 사항
test, dev, serve로 나뉘어져있던 npm script을 서버에서는 serve만 이용하도록 바꾸었습니다.

### 변경점
컨테이너를 띄우고 나서도 서버에 터미널을 연결할 수 있을 것 같습니다!

### 목적
서버의 속도 향상