### PR TITLE
feat: app 레슨 등록/수정 페이지(MNT-C-007) 구현

### DIFF
--- a/munetic_app/src/components/Home.tsx
+++ b/munetic_app/src/components/Home.tsx
@@ -27,7 +27,7 @@ export default function Home() {
           <Button to="/lesson/category">레슨 찾기</Button>
         </div>
         <div className="homeRegisterButton">
-          <Button to="/lesson/write">레슨 등록</Button>
+          <Button to="/lesson/manage">레슨 등록</Button>
         </div>
       </div>
     </Container>

--- a/munetic_app/src/components/common/BottomMenu.tsx
+++ b/munetic_app/src/components/common/BottomMenu.tsx
@@ -8,13 +8,14 @@ import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import BookmarkIcon from '@mui/icons-material/Bookmark';
 import SettingsIcon from '@mui/icons-material/Settings';
 import { styled } from '@mui/material';
+import palette from '../../style/palette';
 
 const BottomNavigationAction = styled(MuiBottomNavigationAction)(`
   &.Mui-selected {
-    color: #1d3557;
+    color: ${palette.darkBlue};
   }
-  background-color: #f1faee;
-  color: #457b9d;
+  background-color: ${palette.ivory};
+  color: ${palette.grayBlue};
 `);
 
 export default function BottomMenu() {

--- a/munetic_app/src/components/common/Button.tsx
+++ b/munetic_app/src/components/common/Button.tsx
@@ -1,12 +1,13 @@
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
+import palette from '../../style/palette';
 
 const Container = styled.button`
   width: 100%;
   border: 0;
   border-radius: 20px;
-  background-color: #457b9d;
-  color: #f1faee;
+  background-color: ${palette.grayBlue};
+  color: ${palette.ivory};
   font-size: 20px;
   font-weight: bold;
   position: relative;

--- a/munetic_app/src/components/common/TopBar.tsx
+++ b/munetic_app/src/components/common/TopBar.tsx
@@ -1,11 +1,12 @@
 import styled from 'styled-components';
 import NotificationsNoneIcon from '@mui/icons-material/NotificationsNone';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
+import palette from '../../style/palette';
 
 const TopBarContainer = styled.div`
   width: 100%;
   height: 50px;
-  background-color: #1d3557;
+  background-color: ${palette.darkBlue};
   position: sticky;
   top: 0;
   z-index: 99;
@@ -21,7 +22,7 @@ const TopBarContainer = styled.div`
     cursor: pointer;
   }
   .topBarIcon {
-    color: #f1faee;
+    color: ${palette.ivory};
   }
   .topBarIconText {
     width: 15px;
@@ -29,8 +30,8 @@ const TopBarContainer = styled.div`
     position: absolute;
     top: -3px;
     left: 10px;
-    background-color: #e63946;
-    color: #f1faee;
+    background-color: ${palette.red};
+    color: ${palette.ivory};
     border-radius: 50%;
     display: flex;
     align-items: center;
@@ -40,7 +41,7 @@ const TopBarContainer = styled.div`
   .logo {
     font-weight: bold;
     font-size: 26px;
-    color: #f1faee;
+    color: ${palette.ivory};
     cursor: pointer;
     line-height: 53px;
   }
@@ -57,12 +58,12 @@ const TopBarContainer = styled.div`
     text-align: right;
   }
   .topBarRightText {
-    color: #f1faee;
+    color: ${palette.ivory};
     font-size: 15px;
     font-weight: bold;
   }
   .topBarLeftText {
-    color: #f1faee;
+    color: ${palette.ivory};
     font-size: 15px;
     font-weight: bold;
   }

--- a/munetic_app/src/components/lesson/CategoryContainer.tsx
+++ b/munetic_app/src/components/lesson/CategoryContainer.tsx
@@ -1,15 +1,16 @@
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { categoryData } from '../../dummy/categoryData';
+import palette from '../../style/palette';
 
 const CategoryPageContainer = styled.div`
   margin: 30px;
   height: 70%;
-  background-color: #457b9d;
+  background-color: ${palette.grayBlue};
   border-radius: 5px;
   .categoryTitle {
     margin: 15px 0px 10px 0px;
-    color: #f1faee;
+    color: ${palette.ivory};
     font-size: 20px;
     font-weight: bold;
   }
@@ -32,7 +33,7 @@ const CategoryButton = styled(Link)`
   width: 28%;
   border: 0;
   border-radius: 7px;
-  background-color: #f1faee;
+  background-color: ${palette.ivory};
   margin: 5px 5px;
   padding: 0;
   position: relative;
@@ -49,7 +50,7 @@ const CategoryButton = styled(Link)`
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    color: #1d3557;
+    color: ${palette.darkBlue};
     font-size: 15px;
     font-weight: bold;
     text-align: center;

--- a/munetic_app/src/components/lesson/Class.tsx
+++ b/munetic_app/src/components/lesson/Class.tsx
@@ -5,16 +5,17 @@ import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import BookmarkBorderIcon from '@mui/icons-material/BookmarkBorder';
 import InstagramIcon from '@mui/icons-material/Instagram';
 import YouTubeIcon from '@mui/icons-material/YouTube';
+import palette from '../../style/palette';
 
 const ClassContainer = styled.div`
   margin: 10px;
-  background-color: #f1faee;
+  background-color: ${palette.ivory};
 `;
 
 const ClassProfileWrapper = styled.div`
   display: flex;
   justify-content: space-between;
-  border-bottom: 1px solid #1d3557;
+  border-bottom: 1px solid ${palette.darkBlue};
   .imgAndNickname {
     margin: 20px;
     display: flex;
@@ -30,7 +31,7 @@ const ClassProfileWrapper = styled.div`
     text-align: center;
     font-size: large;
     font-weight: bold;
-    color: #1d3557;
+    color: ${palette.darkBlue};
   }
   .sns {
     display: flex;
@@ -44,11 +45,11 @@ const ClassPhoneNumber = styled.div`
   padding: 15px 20px;
   font-size: 17px;
   font-weight: bold;
-  color: #1d3557;
-  border-bottom: 1px solid #1d3557;
+  color: ${palette.darkBlue};
+  border-bottom: 1px solid ${palette.darkBlue};
   .phoneNumber {
     font-weight: normal;
-    color: #457b9d;
+    color: ${palette.grayBlue};
   }
 `;
 
@@ -56,8 +57,8 @@ const ClassBasicInfo = styled.div`
   padding: 15px 20px;
   font-size: 17px;
   font-weight: bold;
-  color: #1d3557;
-  border-bottom: 1px solid #1d3557;
+  color: ${palette.darkBlue};
+  border-bottom: 1px solid ${palette.darkBlue};
   .basicInfo {
     margin: 10px 15px 0px 5px;
   }
@@ -72,7 +73,7 @@ const ClassBasicInfo = styled.div`
   .basicInfoDetailValue {
     font-weight: normal;
     flex: 1.5;
-    color: #457b9d;
+    color: ${palette.grayBlue};
   }
 `;
 
@@ -80,8 +81,8 @@ const ClassContent = styled.div`
   padding: 15px 20px;
   font-size: 17px;
   font-weight: bold;
-  color: #1d3557;
-  border-bottom: 1px solid #1d3557;
+  color: ${palette.darkBlue};
+  border-bottom: 1px solid ${palette.darkBlue};
   .contentBox {
     margin: 10px 0;
     padding: 25px 15px;

--- a/munetic_app/src/components/lesson/ClassList.tsx
+++ b/munetic_app/src/components/lesson/ClassList.tsx
@@ -1,7 +1,9 @@
+import { useCallback } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { classData } from '../../dummy/classData';
 import palette from '../../style/palette';
+import Button from '../common/Button';
 
 const ClassListContainer = styled.div`
   margin: 30px;
@@ -15,14 +17,20 @@ const ClassItemContainer = styled(Link)`
   border-radius: 5px;
   .classItemDescription {
     flex: 1;
-    margin: 10px 20px;
+    width: 60%;
+    margin: 10px 10px 10px 20px;
     display: flex;
     flex-direction: column;
   }
   .classItemTitle {
-    margin: 0px 0px 5px 0px;
+    margin: 5px 0px;
+    padding: 1px 0px;
     color: ${palette.ivory};
-    font-size: 18px;
+    display: inline-block;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    font-size: 17px;
     font-weight: bold;
   }
   .classItemCategory {
@@ -37,6 +45,36 @@ const ClassItemContainer = styled(Link)`
     align-items: right;
     border-radius: 50%;
   }
+  .buttons {
+    margin: 5px;
+    display: flex;
+    margin-left: auto;
+  }
+`;
+
+interface StyledButtonProps {
+  deleteBtn?: boolean;
+  to?: string;
+}
+
+const StyledButton = styled(Button)<StyledButtonProps>`
+  background-color: ${palette.ivory};
+  font-size: 9px;
+  width: 40px;
+  height: 40px;
+  border-radius: 5px;
+  margin-left: 5px;
+  .buttonText {
+    margin: 0;
+    color: ${palette.darkBlue};
+  }
+  ${({ deleteBtn }) =>
+    deleteBtn &&
+    css`
+      .buttonText {
+        color: ${palette.red};
+      }
+    `}
 `;
 
 interface lessonType {
@@ -48,17 +86,33 @@ interface lessonType {
 
 interface IProps {
   lesson: lessonType;
+  mode?: string;
 }
 
-const ClassItem = ({ lesson }: IProps) => {
+export const ClassItem = ({ lesson, mode }: IProps) => {
   const { id, title, img, category } = lesson;
+
+  const onClick = useCallback(id => {
+    //추후 id로 레슨 삭제 예정
+    alert(`이 id:${id}를 삭제하시겠습니까?`);
+  }, []);
+
   return (
     <ClassItemContainer to={`/lesson/class/${id}`}>
       <div className="classItemDescription">
-        <span className="classItemTitle">{title}</span>
         <span className="classItemCategory">카테고리 : {category}</span>
+        <span className="classItemTitle">{title}</span>
       </div>
-      <img className="classItemImg" src={img} alt="" />
+      {mode === 'manage' ? (
+        <div className="buttons">
+          <StyledButton to="/lesson/write/id">수정</StyledButton>
+          <StyledButton onClick={() => onClick(id)} deleteBtn to="">
+            삭제
+          </StyledButton>
+        </div>
+      ) : (
+        <img className="classItemImg" src={img} alt="" />
+      )}
     </ClassItemContainer>
   );
 };

--- a/munetic_app/src/components/lesson/ClassManage.tsx
+++ b/munetic_app/src/components/lesson/ClassManage.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import { classData } from '../../dummy/classData';
 import palette from '../../style/palette';
 import Button from '../common/Button';
-import ClassList from './ClassList';
+import ClassList, { ClassItem } from './ClassList';
 
 const ClassManageContainer = styled.div``;
 
@@ -19,64 +19,14 @@ const StyledButton = styled(Button)`
 `;
 
 const ClassListWrapper = styled.div`
-  padding: 40px 30px;
-`;
-
-const ClassItemContainer = styled(Link)`
-  background-color: ${palette.grayBlue};
-  display: flex;
-  align-items: center;
-  margin-bottom: 10px;
-  border-radius: 5px;
-  .classItemDescription {
-    flex: 1;
-    margin: 10px 20px;
-    display: flex;
-    flex-direction: column;
-  }
-  .classItemTitle {
-    margin: 0px 0px 5px 0px;
-    color: ${palette.ivory};
-    font-size: 18px;
-    font-weight: bold;
-  }
-  .classItemCategory {
-    font-size: 12px;
-    font-weight: normal;
-    color: #f1faee96;
-  }
-  .classItemImg {
-    width: 60px;
-    height: 60px;
-    margin: 5px;
-    align-items: right;
-    border-radius: 50%;
+  padding: 30px 30px;
+  font-weight: bold;
+  font-size: 17px;
+  color: ${palette.darkBlue};
+  .classList {
+    margin-top: 20px;
   }
 `;
-
-interface lessonType {
-  id: number;
-  title: string;
-  img: string;
-  category: string;
-}
-
-interface IProps {
-  lesson: lessonType;
-}
-
-const ClassItem = ({ lesson }: IProps) => {
-  const { id, title, img, category } = lesson;
-  return (
-    <ClassItemContainer to={`/lesson/class/${id}`}>
-      <div className="classItemDescription">
-        <span className="classItemTitle">{title}</span>
-        <span className="classItemCategory">카테고리 : {category}</span>
-      </div>
-      <img className="classItemImg" src={img} alt="" />
-    </ClassItemContainer>
-  );
-};
 
 export default function ClassManage() {
   // 나중에는 현재 로그인한 유저 정보 불러와서 매칭되는 레슨 글만 보이도록 해줄 것
@@ -91,7 +41,7 @@ export default function ClassManage() {
         <div className="classList">
           {classData &&
             classData.map(lesson => (
-              <ClassItem lesson={lesson} key={lesson.id} />
+              <ClassItem lesson={lesson} mode="manage" key={lesson.id} />
             ))}
         </div>
       </ClassListWrapper>

--- a/munetic_app/src/components/lesson/ClassManage.tsx
+++ b/munetic_app/src/components/lesson/ClassManage.tsx
@@ -1,10 +1,25 @@
-import { Link, useSearchParams } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { classData } from '../../dummy/classData';
 import palette from '../../style/palette';
+import Button from '../common/Button';
+import ClassList from './ClassList';
 
-const ClassListContainer = styled.div`
-  margin: 30px;
+const ClassManageContainer = styled.div``;
+
+const WriteBtnWrapper = styled.div`
+  padding: 80px 30px;
+  border-bottom: 1px solid ${palette.darkBlue};
+`;
+
+const StyledButton = styled(Button)`
+  ::before {
+    padding-top: 50%;
+  }
+`;
+
+const ClassListWrapper = styled.div`
+  padding: 40px 30px;
 `;
 
 const ClassItemContainer = styled(Link)`
@@ -63,21 +78,24 @@ const ClassItem = ({ lesson }: IProps) => {
   );
 };
 
-export default function ClassList() {
-  const [getParams, setParams] = useSearchParams();
-  const categoryParam = getParams.get('category');
+export default function ClassManage() {
+  // 나중에는 현재 로그인한 유저 정보 불러와서 매칭되는 레슨 글만 보이도록 해줄 것
+
   return (
-    <ClassListContainer>
-      {classData &&
-        (categoryParam === '전체'
-          ? classData.map(lesson => (
+    <ClassManageContainer>
+      <WriteBtnWrapper>
+        <StyledButton to="/lesson/write">레슨 글 등록하기</StyledButton>
+      </WriteBtnWrapper>
+      <ClassListWrapper>
+        등록된 레슨
+        <div className="classList">
+          {classData &&
+            classData.map(lesson => (
               <ClassItem lesson={lesson} key={lesson.id} />
-            ))
-          : classData.map(lesson => {
-              if (lesson.category === categoryParam) {
-                return <ClassItem lesson={lesson} key={lesson.id} />;
-              }
-            }))}
-    </ClassListContainer>
+            ))}
+        </div>
+      </ClassListWrapper>
+      <ClassList />
+    </ClassManageContainer>
   );
 }

--- a/munetic_app/src/dummy/classData.tsx
+++ b/munetic_app/src/dummy/classData.tsx
@@ -44,7 +44,7 @@ export const classData = [
   },
   {
     id: 4,
-    title: '드럼 빼고 다 가능인데 드럼 강의함',
+    title: '드럼 빼고 다 가능인데 드럼 강의함 잘리나 테스트',
     img: '/img/testImg.png',
     category: '드럼',
     nickname: 'nobody',

--- a/munetic_app/src/pages/lesson/ManageClassPage.tsx
+++ b/munetic_app/src/pages/lesson/ManageClassPage.tsx
@@ -1,7 +1,5 @@
+import ClassManage from '../../components/lesson/ClassManage';
+
 export default function ManageClassPage() {
-  return (
-    <div>
-      <div>레슨 등록/수정 페이지</div>
-    </div>
-  );
+  return <ClassManage />;
 }

--- a/munetic_app/src/style/palette.ts
+++ b/munetic_app/src/style/palette.ts
@@ -1,0 +1,7 @@
+export default {
+  darkBlue: '#1d3557',
+  grayBlue: '#457b9d',
+  lightBlue: '#a8dadc',
+  ivory: '#f1faee',
+  red: '#e63946',
+};


### PR DESCRIPTION
### 개요
레슨 등록/수정 페이지(MNT-C-007) 구현
### 작업 사항
- 레슨 등록 버튼 생성
- 내 아이디로 등록된 레슨 리스트 출력을 해야하나 일단 전체 레슨 목록만 출력
- 레슨 별 수정/삭제 버튼 만듦
### 변경점
- 레슨 등록 버튼으로 /lesson/write 페이지로 이동 가능
- 현재 레슨 목록을 볼 수 있음(추후 내가 작성한 글만 보이게 수정 예정)
- 수정 버튼 클릭시 수정페이지로 이동하고 삭제 버튼은 현재는 alert 창만 구현
### 목적
- 레슨 글 등록, 수정, 삭제, 내 글 보기 기능을 하기 위함
### 스크린샷 (optional)
![image](https://user-images.githubusercontent.com/76505351/146964007-66e8c754-49b0-476b-a578-8b204c84c7eb.png)
