### PR TITLE
fix: #81 install serve package to admin and app

### DIFF
--- a/munetic_admin/package.json
+++ b/munetic_admin/package.json
@@ -16,6 +16,7 @@
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
     "react-router-dom": "^6.0.2",
+    "serve": "^13.0.2",
     "styled-components": "^5.3.3",
     "styled-reset": "^4.3.4"
   },


### PR DESCRIPTION
### 개요
admin과 app에 serve가 설치되어있지 않아 develop에 푸시 시 배포가 되지
않는 오류가 있었습니다.

### 작업 사항
serve를 package.json에 추가하여 해결하도록 하였습니다.


### 변경점
이제 serve때문에 서버가 멈추지 않습니다.

### 목적
서버를 진정시키기 위해...
