### PR TITLE
feat: 로그인 api 와 클라이언트 연결 작업

### DIFF
--- a/munetic_app/src/App.tsx
+++ b/munetic_app/src/App.tsx
@@ -1,19 +1,16 @@
 import BottomMenu from './components/common/BottomMenu';
 import TopBar from './components/common/TopBar';
-import { ContextProvider } from './context/Contexts';
 import Routing from './Routing';
 import GlobalStyle from './style/GlobalStyle';
 
 function App() {
   return (
-    <ContextProvider>
-      <div>
-        <GlobalStyle />
-        <TopBar />
-        <Routing />
-        <BottomMenu />
-      </div>
-    </ContextProvider>
+    <div>
+      <GlobalStyle />
+      <TopBar />
+      <Routing />
+      <BottomMenu />
+    </div>
   );
 }
 

--- a/munetic_app/src/components/Home.tsx
+++ b/munetic_app/src/components/Home.tsx
@@ -1,5 +1,8 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import Button from './common/Button';
+import * as Auth from '../lib/api/auth';
 
 const Container = styled.div`
   margin: 30px 0px;
@@ -20,6 +23,32 @@ const Container = styled.div`
 `;
 
 export default function Home() {
+  const [loggedUser, setLoggedUser] = useState(localStorage.getItem('user'));
+
+  const navigate = useNavigate();
+
+  const onClickLogin = () => {
+    navigate('/auth/login');
+  };
+
+  const onClickLogout = async () => {
+    try {
+      await Auth.logout();
+      try {
+        localStorage.removeItem('user');
+      } catch (e) {
+        console.log(e, 'localStorage is not working');
+      }
+      setLoggedUser(localStorage.getItem('user'));
+    } catch (e) {
+      console.log(e, '로그아웃 실패');
+    }
+  };
+
+  const onClickSignup = () => {
+    navigate('/auth/register');
+  };
+
   return (
     <Container>
       <div className="homeButtonWrapper">
@@ -30,6 +59,10 @@ export default function Home() {
           <Button to="/lesson/manage">레슨 등록</Button>
         </div>
       </div>
+      <button onClick={loggedUser ? onClickLogout : onClickLogin}>
+        {loggedUser ? '로그아웃' : '로그인'}
+      </button>
+      <button onClick={onClickSignup}>회원가입</button>
     </Container>
   );
 }

--- a/munetic_app/src/components/auth/Login.tsx
+++ b/munetic_app/src/components/auth/Login.tsx
@@ -6,6 +6,7 @@ import { InputBox } from '../common/Input';
 import * as AuthAPI from '../../lib/api/auth';
 import Contexts from '../../context/Contexts';
 import { useNavigate } from 'react-router-dom';
+import client from '../../lib/api/client';
 
 const Container = styled.form`
   margin: 250px 30px 30px 30px;
@@ -34,7 +35,7 @@ const StyledButton = styled(Button)`
 `;
 
 export default function Login() {
-  const { state, actions } = useContext(Contexts);
+  const { actions } = useContext(Contexts);
   const [loginInfo, setLoginInfo] = useState({
     login_id: '',
     login_password: '',
@@ -70,11 +71,20 @@ export default function Login() {
 
     if (validateLoginForm()) {
       try {
-        await AuthAPI.login(loginInfo);
+        const res = await AuthAPI.login(loginInfo);
+        const { data: accessToken } = res.data;
+        client.defaults.headers.common[
+          'Authorization'
+        ] = `Bearer ${accessToken}`;
+        try {
+          localStorage.setItem('user', JSON.stringify(login_id));
+        } catch (e) {
+          console.log(e, 'localStorage is not working');
+        }
         navigate('/');
       } catch (e) {
         setShowErrorMessage(true);
-        console.log(e, '회원가입 실패');
+        console.log(e, '로그인 실패');
       }
     }
   };
@@ -84,6 +94,12 @@ export default function Login() {
       actions.setValidationMode(false);
       setShowErrorMessage(false);
     };
+  }, []);
+
+  useEffect(() => {
+    if (localStorage.getItem('user')) {
+      navigate('/');
+    }
   }, []);
 
   return (

--- a/munetic_app/src/components/auth/Register.tsx
+++ b/munetic_app/src/components/auth/Register.tsx
@@ -200,7 +200,7 @@ export default function Register() {
     if (validateSignupForm()) {
       try {
         await AuthAPI.signup(registerInfo);
-        navigate('/');
+        navigate('/auth/login');
       } catch (e) {
         console.log(e, '회원가입 실패');
       }
@@ -208,7 +208,6 @@ export default function Register() {
   };
 
   const onClickCheckId = async (id: string) => {
-    //get 요청 query형태에 따라 다시 바꾸자. 현재는 /api/auth/user?kunlee
     if (id) {
       try {
         await AuthAPI.isValidInfo(`login_id=${id}`);

--- a/munetic_app/src/lib/api/auth.ts
+++ b/munetic_app/src/lib/api/auth.ts
@@ -5,5 +5,8 @@ export const signup = (userSignupData: userSignupData) =>
   client.post('/api/auth/signup', userSignupData);
 export const login = (body: { login_id: string; login_password: string }) =>
   client.post('/api/auth/login', body);
+export const logout = () => client.get('/api/auth/logout');
 export const isValidInfo = (body: string) =>
   client.get(`/api/auth/signup/user?${body}`);
+
+export const refresh = () => client.get('/api/auth/refresh');

--- a/munetic_app/src/lib/api/client.ts
+++ b/munetic_app/src/lib/api/client.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 
 const client = axios.create({
   baseURL: 'http://localhost:3030',
+  withCredentials: true,
 });
 
 export default client;

--- a/munetic_app/src/lib/api/profile.ts
+++ b/munetic_app/src/lib/api/profile.ts
@@ -1,0 +1,13 @@
+import client from './client';
+
+export interface NewProfileInfoType {
+  type?: string;
+  nickname?: string;
+  name_public?: boolean;
+  phone_public?: boolean;
+  image_url?: string | null;
+  introduction?: string | null;
+}
+export const updateProfile = (id: number, body: NewProfileInfoType) =>
+  client.patch(`/api/user/${id}`, body);
+export const getProfileById = (id: number) => client.get(`/api/user/${id}`);

--- a/munetic_app/src/main.tsx
+++ b/munetic_app/src/main.tsx
@@ -2,11 +2,36 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
+import { ContextProvider } from './context/Contexts';
+import * as Auth from './lib/api/auth';
+import client from './lib/api/client';
+
+async function loadUser() {
+  try {
+    const loggedUser = localStorage.getItem('user');
+    if (!loggedUser) {
+      return;
+    }
+    try {
+      const res = await Auth.refresh();
+      const { data: accessToken } = res.data;
+      client.defaults.headers.common['Authorization'] = `Bearer ${accessToken}`;
+    } catch (e) {
+      console.log(e, '로그인을 유지하지 못했습니다.');
+    }
+  } catch (e) {
+    console.log(e, 'localStorage is not working');
+  }
+}
+
+loadUser();
 
 ReactDOM.render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <ContextProvider>
+        <App />
+      </ContextProvider>
     </BrowserRouter>
   </React.StrictMode>,
   document.getElementById('root'),

--- a/munetic_express/src/app.ts
+++ b/munetic_express/src/app.ts
@@ -12,7 +12,13 @@ import passport from 'passport';
 const app: express.Application = express();
 
 app.use(express.json());
-app.use(cors());
+app.use(
+  cors({
+    origin: 'http://localhost:2424',
+    credentials: true,
+    exposedHeaders: 'Authorization',
+  }),
+);
 app.use(cookieParser());
 app.use(passport.initialize());
 app.use('/api', router);


### PR DESCRIPTION
### 개요
로그인 api 와 클라이언트 연결 작업
### 작업 사항
- App 컴포넌트에서 context api 사용할 일 있을까해서 provider 이동(App.ts -> main.ts)
- 로그인 처리 방식: 로그인 성공 시 response로 refreshToken을 받아 쿠키에 저장하고 accessToken도 response로 받지만 요청 header 설정만 해주고 사라짐 -> 로그인 상태에서 요청시 header에 accessToken이 담겨져서 요청하는 형태
- 로그아웃 처리 방식: 로그아웃 성공 시 refreshToken, localStorage 삭제
- 새로고침해도 로그인 유지되는 방식: 로그인 성공하면 login_id를 localStorage에 저장 -> 새로고침 시 main 컴포넌트 렌더링되면서  localStorage 에 저장된 user가 있으면 refresh api 통신을 통해 accessToken을 받아와서 header에 넣어줌 -> localStorage 에 저장된 user가 없으면 토큰 요청 안함
- 홈화면에 임시로 로그인, 회원가입 버튼 생성 -> 로그인 성공시 로그아웃으로 변함(localStorage에서 값을 읽어와서 state로 저장하여 변화를 확인)
- 로그인 상태에서 경로로 로그인 페이지 접속 시 홈화면으로 이동하도록 함
- 회원가입 성공시 로그인 페이지로 이동하도록 변경
- auth.ts 에 있던 프로필 관련 api를 profile.ts 로 이동
- app.ts(express)의 cors 옵션을 주어 로컬에서 실행시 withCredentials 옵션을 주었을때 쿠키를 저장하지 못하는 오류 해결
### 변경점
-로그인 및 새로고침 시 로그인 유지 기능 추가
### 목적
- 로그인을 가능하게 하여 로그인한 유저의 상태를 처리할 수 있도록 함
### 스크린샷 (optional)
