### PR TITLE
feat: 내 프로필 조회, 수정, 전체 조회 api 인가

### DIFF
--- a/munetic_app/src/components/Home.tsx
+++ b/munetic_app/src/components/Home.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import Button from './common/Button';
 import * as Auth from '../lib/api/auth';
+import * as ProfileAPI from '../lib/api/profile';
+import client from '../lib/api/client';
 
 const Container = styled.div`
   margin: 30px 0px;
@@ -35,6 +37,7 @@ export default function Home() {
     try {
       await Auth.logout();
       try {
+        client.defaults.headers.common['Authorization'] = '';
         localStorage.removeItem('user');
       } catch (e) {
         console.log(e, 'localStorage is not working');
@@ -47,6 +50,42 @@ export default function Home() {
 
   const onClickSignup = () => {
     navigate('/auth/register');
+  };
+
+  const onClickProfileView = async () => {
+    try {
+      const res = await ProfileAPI.getMyProfile();
+      console.log(res.data.data);
+    } catch (e) {
+      console.log(e, '내 프로필 보기 실패');
+    }
+  };
+
+  const onClickProfileViewOthers = async () => {
+    try {
+      const id = 3;
+      const res = await ProfileAPI.getProfileById(id);
+      console.log(res.data.data);
+    } catch (e) {
+      console.log(e, '다른 사람 프로필 보기 실패');
+    }
+  };
+
+  const onClickProfileEdit = async () => {
+    try {
+      const newData = {
+        type: 'Student',
+        nickname: 'kunkun',
+        name_public: true,
+        phone_public: false,
+        image_url: '/img/test.png',
+        introduction: 'test',
+      };
+      const res = await ProfileAPI.updateProfile(newData);
+      console.log(res.data.data);
+    } catch (e) {
+      console.log(e, '내 프로필 수정 실패');
+    }
   };
 
   return (
@@ -63,6 +102,9 @@ export default function Home() {
         {loggedUser ? '로그아웃' : '로그인'}
       </button>
       <button onClick={onClickSignup}>회원가입</button>
+      <button onClick={onClickProfileView}>내 프로필 조회</button>
+      <button onClick={onClickProfileEdit}>내 프로필 수정</button>
+      <button onClick={onClickProfileViewOthers}>다른 사람 프로필 조회</button>
     </Container>
   );
 }

--- a/munetic_app/src/lib/api/profile.ts
+++ b/munetic_app/src/lib/api/profile.ts
@@ -8,6 +8,8 @@ export interface NewProfileInfoType {
   image_url?: string | null;
   introduction?: string | null;
 }
-export const updateProfile = (id: number, body: NewProfileInfoType) =>
-  client.patch(`/api/user/${id}`, body);
-export const getProfileById = (id: number) => client.get(`/api/user/${id}`);
+export const updateProfile = (body: NewProfileInfoType) =>
+  client.patch(`/api/user`, body);
+export const getProfileById = (id: number) =>
+  client.get(`/api/user/profile/${id}`);
+export const getMyProfile = () => client.get(`/api/user/logged`);

--- a/munetic_express/src/@types/express.d.ts
+++ b/munetic_express/src/@types/express.d.ts
@@ -3,6 +3,7 @@ declare module Express {
     user?: {
       login_id: string;
       id: number;
+      login_password?: string;
     };
   }
 }

--- a/munetic_express/src/@types/express.d.ts
+++ b/munetic_express/src/@types/express.d.ts
@@ -1,0 +1,8 @@
+declare module Express {
+  export interface Request {
+    user?: {
+      login_id: string;
+      id: number;
+    };
+  }
+}

--- a/munetic_express/src/controllers/user.controller.ts
+++ b/munetic_express/src/controllers/user.controller.ts
@@ -1,17 +1,40 @@
 import { RequestHandler } from 'express';
 import * as Status from 'http-status';
+import ErrorResponse from '../modules/errorResponse';
 import { ResJSON } from '../modules/types';
 import * as UserService from '../service/user.service';
 
 export const getAllUserProfile: RequestHandler = async (req, res, next) => {
   try {
-    let result: ResJSON;
-    const users = await UserService.findAllUser(Number(req.query.page));
-    result = new ResJSON(
-      '모든 유저 프로필을 불러오는데 성공하였습니다.',
-      users,
-    );
-    res.status(Status.OK).json(result);
+    if (req.user) {
+      let result: ResJSON;
+      const users = await UserService.findAllUser(Number(req.query.page));
+      result = new ResJSON(
+        '모든 유저 프로필을 불러오는데 성공하였습니다.',
+        users,
+      );
+      res.status(Status.OK).json(result);
+    } else {
+      next(new ErrorResponse(Status.UNAUTHORIZED, '로그인이 필요합니다.'));
+    }
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const getMyProfile: RequestHandler = async (req, res, next) => {
+  try {
+    if (req.user) {
+      let result: ResJSON;
+      const userData = await UserService.findUserById(Number(req.user.id));
+      result = new ResJSON(
+        '유저 프로필을 불러오는데 성공하였습니다.',
+        userData,
+      );
+      res.status(Status.OK).json(result);
+    } else {
+      next(new ErrorResponse(Status.UNAUTHORIZED, '로그인이 필요합니다.'));
+    }
   } catch (err) {
     next(err);
   }
@@ -33,16 +56,17 @@ export const getUserProfile: RequestHandler = async (req, res, next) => {
 
 export const editUserProfile: RequestHandler = async (req, res, next) => {
   try {
-    if (!req.params.id) {
-      res.status(Status.BAD_REQUEST).send('유저 아이디가 없습니다.');
+    if (req.user) {
+      let result: ResJSON;
+      const user = await UserService.editUserById(
+        Number(req.user.id),
+        req.body,
+      );
+      result = new ResJSON('유저 프로필을 수정하는데 성공하였습니다.', user);
+      res.status(Status.OK).json(result);
+    } else {
+      next(new ErrorResponse(Status.UNAUTHORIZED, '로그인이 필요합니다.'));
     }
-    let result: ResJSON;
-    const user = await UserService.editUserById(
-      Number(req.params.id),
-      req.body,
-    );
-    result = new ResJSON('유저 프로필을 수정하는데 성공하였습니다.', user);
-    res.status(Status.OK).json(result);
   } catch (err) {
     next(err);
   }

--- a/munetic_express/src/controllers/user.controller.ts
+++ b/munetic_express/src/controllers/user.controller.ts
@@ -26,7 +26,8 @@ export const getMyProfile: RequestHandler = async (req, res, next) => {
   try {
     if (req.user) {
       let result: ResJSON;
-      const userData = await UserService.findUserById(Number(req.user.id));
+      const userData = req.user;
+      delete userData.login_password;
       result = new ResJSON(
         '유저 프로필을 불러오는데 성공하였습니다.',
         userData,

--- a/munetic_express/src/modules/jwt.strategy.ts
+++ b/munetic_express/src/modules/jwt.strategy.ts
@@ -23,7 +23,8 @@ const JwtStrategyCallback = async (
 ) => {
   const [user] = await UserService.search({ login_id: jwt_payload.login_id });
   if (user) {
-    return done(null, user.login_id);
+    const userData = { login_id: user.login_id, id: user.id };
+    return done(null, userData);
   } else {
     return done(null, null);
   }

--- a/munetic_express/src/modules/jwt.strategy.ts
+++ b/munetic_express/src/modules/jwt.strategy.ts
@@ -23,8 +23,7 @@ const JwtStrategyCallback = async (
 ) => {
   const [user] = await UserService.search({ login_id: jwt_payload.login_id });
   if (user) {
-    const userData = { login_id: user.login_id, id: user.id };
-    return done(null, userData);
+    return done(null, user.toJSON());
   } else {
     return done(null, null);
   }

--- a/munetic_express/src/routes/user.routes.ts
+++ b/munetic_express/src/routes/user.routes.ts
@@ -1,13 +1,14 @@
 import { Router } from 'express';
-import {
-  editUserProfile,
-  getAllUserProfile,
-  getUserProfile,
-} from '../controllers/user.controller';
+import passport from 'passport';
+import * as UserAPI from '../controllers/user.controller';
+import JwtStrategy from '../modules/jwt.strategy';
 
 export const path = '/user';
 export const router = Router();
 
-router.get('/', getAllUserProfile);
-router.get('/:id', getUserProfile);
-router.patch('/:id', editUserProfile);
+passport.use('jwt', JwtStrategy());
+
+router.get('/', passport.authenticate('jwt'), UserAPI.getAllUserProfile);
+router.get('/profile/:id', UserAPI.getUserProfile);
+router.patch('/', passport.authenticate('jwt'), UserAPI.editUserProfile);
+router.get('/logged', passport.authenticate('jwt'), UserAPI.getMyProfile);

--- a/munetic_express/src/swagger.yml
+++ b/munetic_express/src/swagger.yml
@@ -200,7 +200,7 @@ paths:
             example: 'JWT expired'
 
   # USER 관련 API
-  /user/{id}:
+  /user/profile/{id}:
     get:
       tags:
         - User
@@ -234,16 +234,18 @@ paths:
               message:
                 type: string
                 example: 'Failed'
+
+  /user:
     patch:
       tags:
         - User
-      summary: Edit profile by ID
+      summary: Edit my profile
       parameters:
-        - name: id
-          in: path
-          required: true
-          description: user ID
+        - in: header
           type: string
+          name: accessToken
+          required: true
+          description: user accessToken
         - name: body
           in: body
           description: Edit contents
@@ -251,7 +253,7 @@ paths:
             type: object
             properties:
               type:
-                enum: ['STUDENT', 'TUTOR']
+                enum: ['Student', 'Tutor']
               nickname:
                 type: string
               name_public:
@@ -273,13 +275,82 @@ paths:
                 example: 'Success'
               data:
                 $ref: '#/definitions/User'
-        '400':
-          description: Invalid ID
+        '401':
+          description: Unauthorized
           schema:
             type: object
             properties:
               message:
                 type: string
+
+    get:
+      tags:
+        - User
+      summary: Get All user profile
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: header
+          type: string
+          name: accessToken
+          required: true
+          description: user accessToken
+      responses:
+        '200':
+          description: Succesfully got All user profile
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: 'Success'
+              data:
+                $ref: '#/definitions/User'
+        '401':
+          description: Unauthorized
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: 'Failed'
+
+  /user/logged:
+    get:
+      tags:
+        - User
+      summary: Get My profile
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: header
+          type: string
+          name: accessToken
+          required: true
+          description: user accessToken
+      responses:
+        '200':
+          description: Succesfully got My profile
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: 'Success'
+              data:
+                $ref: '#/definitions/User'
+        '401':
+          description: Unauthorized
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: 'Failed'
   #Lesson 관련 API
   /lesson/{id}:
     get:

--- a/munetic_express/tsconfig.json
+++ b/munetic_express/tsconfig.json
@@ -30,7 +30,10 @@
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-    // "typeRoots": [],                                  /* Specify multiple folders that act like `./node_modules/@types`. */
+    "typeRoots": [
+      "./src/@types",
+      "./node_modules/@types"
+    ] /* Specify multiple folders that act like `./node_modules/@types`. */,
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     "resolveJsonModule": true /* Enable importing .json files */,


### PR DESCRIPTION
### 개요
내 프로필 조회, 수정, 전체 조회 api 인가
### 작업 사항
- app 홈화면에 '내 프로필 조회', '내 프로필 수정', '다른 사람 프로필 조회' 버튼 만들어서 클릭시 각각 api와 통신결과를 볼 수 있도록 함
- 프로필 수정 api 는 액세스토큰을 보내서 id를 찾아 사용하므로 get 요청에서 id 인자 보내던 것을 없앰
- 내 프로필 조회 api 추가
- jwtStrategyCallback 에서 user에 login_id만 저장하던 것에 id 추가 저장
- user 컨트롤러 함수에 내 프로필 조회하는 getMyProfile 함수 생성, 기존에 로그인 없이도 프로필 수정 요청이 가능했던 editUserProfile 함수, getAllUserProfile 함수를 수정하여 로그인이 필요하게끔 변경 
### 변경점
- 로그인 상태에서만 내 프로필 조회, 수정, 전체 조회가 가능합니다.
### 목적
-
### 스크린샷 (optional)
