### PR TITLE
feature: 유저 아이디로 레슨 조회 가능

### DIFF
--- a/munetic_express/package.json
+++ b/munetic_express/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watchAll ",
+    "build": "tsc",
     "dev": "tsc-watch --onSuccess \"ts-node dist/server.js\"",
     "serve": "tsc && node dist/server.js"
   },

--- a/munetic_express/src/controllers/lesson.controller.ts
+++ b/munetic_express/src/controllers/lesson.controller.ts
@@ -2,10 +2,12 @@ import { NextFunction, Request, RequestHandler, Response } from 'express';
 import * as status from 'http-status';
 import { Gender } from '../models/user';
 import {
+  CountRows,
   createLesson,
   editLesson,
   findLesson,
   findLessons,
+  findLessonsByUserId,
   LessonAllInfo,
   LessonEditable,
   removeLesson,
@@ -20,6 +22,7 @@ export interface LessonRes extends ResponseData {
   tutor_name: string;
   gender?: Gender;
   birth: Date;
+  phone_number: string | null;
   image_url: string | null;
   editable: LessonEditable;
 }
@@ -73,7 +76,7 @@ const lessonAllInfoToRes = ({
   minute_per_lesson,
   content,
   Category: { name: category },
-  User: { name, nickname, name_public, gender, birth, image_url: image_url },
+  User: { name, nickname, name_public, phone_number, gender, birth, image_url },
 }: LessonAllInfo): LessonRes => {
   return {
     lesson_id,
@@ -81,6 +84,7 @@ const lessonAllInfoToRes = ({
     tutor_name: (name_public ? name : nickname) as string,
     gender,
     birth,
+    phone_number,
     image_url,
     editable: {
       category,
@@ -178,7 +182,13 @@ export const getLessons: RequestHandler = (
     findLessons(offset, limit),
     res,
     next,
-    intoArrayFunc(lessonAllInfoToRes),
+    function (result: CountRows<LessonAllInfo>) {
+      const retCR: CountRows<LessonRes> = { count: result.count, rows: [] };
+      for (const elem of result.rows) {
+        retCR.rows.push(lessonAllInfoToRes(elem));
+      }
+      return retCR;
+    },
   );
 };
 
@@ -210,7 +220,34 @@ export const deleteLesson: RequestHandler = (
   next: NextFunction,
 ) => {
   if (!req.params.id)
-    res.status(status.BAD_REQUEST).send(new ResJSON('No lesson_id requested'));
+    res.status(status.BAD_REQUEST).send(new ResJSON('레슨 아이디가 없습니다.'));
 
   processService(removeLesson(parseInt(req.params.id)), res, next, _ => _);
+};
+
+export const getUserLessons: RequestHandler = (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  if (!req.params.id)
+    res.status(status.BAD_REQUEST).send(new ResJSON('레슨 아이디가 없습니다.'));
+  if (!req.query.offset || !req.query.limit)
+    res.status(status.BAD_REQUEST).send('offset 혹은 limit이 없습니다.');
+  const offset = Number.parseInt(req.query.offset as string);
+  const limit = Number.parseInt(req.query.limit as string);
+  if (!Number.isInteger(offset) || !Number.isInteger(limit))
+    res.status(status.BAD_REQUEST).send('offset 혹은 limit이 정수가 아닙니다.');
+  processService(
+    findLessonsByUserId(parseInt(req.params.id), offset, limit),
+    res,
+    next,
+    function (result: CountRows<LessonAllInfo>) {
+      const retCR: CountRows<LessonRes> = { count: result.count, rows: [] };
+      for (const elem of result.rows) {
+        retCR.rows.push(lessonAllInfoToRes(elem));
+      }
+      return retCR;
+    },
+  );
 };

--- a/munetic_express/src/routes/lesson.routes.ts
+++ b/munetic_express/src/routes/lesson.routes.ts
@@ -3,6 +3,7 @@ import {
   deleteLesson,
   getLesson,
   getLessons,
+  getUserLessons,
   patchLesson,
   postLesson,
 } from '../controllers/lesson.controller';
@@ -15,4 +16,5 @@ router
   .get('/', getLessons) // findLessons
   .get('/:id', getLesson) // findLesson
   .patch('/:id', patchLesson) // editLesson
-  .delete('/:id', deleteLesson); // removeLesson
+  .delete('/:id', deleteLesson) // removeLesson
+  .get('/user/:id', getUserLessons); // findLessonsByUserId

--- a/munetic_express/src/server.ts
+++ b/munetic_express/src/server.ts
@@ -6,3 +6,5 @@ app.listen(3030, () =>
           🚀 App listening on the port 3030
           =============`),
 );
+
+lessonTest();

--- a/munetic_express/src/swagger.yml
+++ b/munetic_express/src/swagger.yml
@@ -377,7 +377,7 @@ paths:
           required: true
       responses:
         '200':
-          description: 'Successful: a lesson is returned'
+          description: 성공적으로 레슨 조회에 성공하였을 때
           schema:
             required:
               - message
@@ -385,11 +385,11 @@ paths:
             properties:
               message:
                 type: string
-                example: a lesson is successfully retrived
+                example: 응답에 성공하였습니다.
               data:
                 $ref: '#/definitions/Lesson'
         '400':
-          description: 'Bad Request: id is missing or not a number'
+          description: id에 맞는 레슨이 없을 때
           schema:
             required:
               - message
@@ -397,19 +397,7 @@ paths:
             properties:
               message:
                 type: string
-                example: 'id is missing or not a number'
-              data:
-                type: object
-        '409':
-          description: "Conflict: id is number but there's no corresponding data"
-          schema:
-            required:
-              - message
-              - data
-            properties:
-              message:
-                type: string
-                example: 'no such lesson'
+                example: 해당하는 레슨이 없습니다.
               data:
                 type: object
     patch:
@@ -523,6 +511,40 @@ paths:
               data:
                 type: object
   /lesson/:
+    get:
+      tags:
+        - Lesson
+      summary: '한 번에 여러 개의 레슨을 조회하는 api'
+      description: ''
+      operationId: getLessons
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: offset
+          in: query
+          type: integer
+          format: int32
+          required: true
+        - name: limit
+          in: query
+          type: integer
+          format: int32
+          required: true
+      responses:
+        '200':
+          description: 최소 1 개의 레슨을 가져오는데 성공하였을 때
+          schema:
+            required:
+              - message
+              - data
+            properties:
+              message:
+                type: string
+                example: 응답에 성공하였습니다.
+              data:
+                $ref: '#/definitions/LessonCounts'
     post:
       tags:
         - Lesson
@@ -570,7 +592,79 @@ paths:
               data:
                 type: object
                 example:
+  /lesson/user/:id:
+    get:
+      tags:
+        - Lesson
+      summary: '한 유저의 레슨을 조회하는 api'
+      description: ''
+      operationId: getLessons
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: id
+          in: path
+          type: integer
+          format: int32
+          required: true
+        - name: offset
+          in: query
+          type: integer
+          format: int32
+          required: true
+        - name: limit
+          in: query
+          type: integer
+          format: int32
+          required: true
+      responses:
+        '200':
+          description: 최소 1 개의 레슨을 가져오는데 성공하였을 때
+          schema:
+            required:
+              - message
+              - data
+            properties:
+              message:
+                type: string
+                example: 응답에 성공하였습니다.
+              data:
+                $ref: '#/definitions/LessonCounts'
+        '400':
+          description: 레슨을 가져오는데 실패하였을 때
+          schema:
+            required:
+              - message
+              - data
+            properties:
+              message:
+                type: string
+                example: 해당하는 유저의 레슨이 더 이상 없습니다.
+              data:
+                type: object
+                example: {}
+
 definitions:
+  LessonCounts:
+    type: object
+    required:
+      - count
+      - rows
+    properties:
+      count:
+        type: integer
+      rows:
+        type: array
+        items:
+          $ref: '#/definitions/Lesson'
+    example:
+      count: 5
+      rows:
+        - $ref: '#/definitions/Lesson/example'
+        - $ref: '#/definitions/Lesson/example'
+        - $ref: '#/definitions/Lesson/example'
   Login:
     type: object
     required:

--- a/munetic_express/src/tests/db/lesson.service.dbtest.ts
+++ b/munetic_express/src/tests/db/lesson.service.dbtest.ts
@@ -6,6 +6,7 @@ import {
   editLesson,
   findLesson,
   findLessons,
+  findLessonsByUserId,
   LessonEditable,
   removeLesson,
 } from '../../service/lesson.service';
@@ -147,27 +148,39 @@ export function lessonTest() {
 
       {
         const res = await findLessons(0, 0);
-        const expected: void[] = [];
+        const expected = { count: 4, rows: [] };
         console.log('findLessons test1.');
         console.log('deepEqual:', deepEqual(expected, res));
       }
       {
         const res_raw = await findLessons(1, 1);
-        const res = [];
-        const expected = [seeds.lesson2];
-        for (const lesson of res_raw) {
-          res.push(JSON.parse(JSON.stringify(lesson)));
-        }
+        let res;
+
+        const expected = { count: 4, rows: [seeds.lesson2] };
+        if (typeof res_raw !== 'string') {
+          res = { ...res_raw };
+          res.rows = [];
+          for (const lesson of res.rows) {
+            res.rows.push(JSON.parse(JSON.stringify(lesson)));
+          }
+        } else res = res_raw;
         console.log('findLessons test2.');
         console.log('deepEqual:', deepEqual(expected, res));
       }
       {
         const res_raw = await findLessons(0, 3);
-        const res = [];
-        for (const lesson of res_raw) {
-          res.push(JSON.parse(JSON.stringify(lesson)));
-        }
-        const expected = [seeds.lesson1, seeds.lesson2, seeds.lesson3];
+        let res;
+        if (typeof res_raw !== 'string') {
+          res = { ...res_raw };
+          res.rows = [];
+          for (const lesson of res.rows) {
+            res.rows.push(JSON.parse(JSON.stringify(lesson)));
+          }
+        } else res = res_raw;
+        const expected = {
+          count: 4,
+          rows: [seeds.lesson1, seeds.lesson2, seeds.lesson3],
+        };
         console.log('findLessons test3.');
         console.log('deepEqual:', deepEqual(expected, res));
       }
@@ -179,9 +192,23 @@ export function lessonTest() {
       }
       {
         const res = await findLessons(12341, 234234);
-        const expected: void[] = [];
+        const expected = { count: 4, rows: [] };
         console.log('findLessons test4.');
         console.log('equal:', deepEqual(expected, res));
+      }
+      {
+        const res_raw = await findLessonsByUserId(2, 1, 1);
+        let res;
+        if (typeof res_raw !== 'string') {
+          res = { ...res_raw };
+          res.rows = [];
+          for (const lesson of res.rows) {
+            res.rows.push(JSON.parse(JSON.stringify(lesson)));
+          }
+        } else res = res_raw;
+        const expected = { count: 3, rows: [seeds.lesson2] };
+        console.log('findLessonByUserId test1.');
+        console.log('deepEqual:', deepEqual(expected, res));
       }
     } catch (e) {
       console.log(e);

--- a/munetic_express/src/tests/db/lessonseeds.ts
+++ b/munetic_express/src/tests/db/lessonseeds.ts
@@ -5,6 +5,7 @@ export const user1 = {
   name: '쿠운리',
   gender: Gender.Male,
   name_public: true,
+  phone_number: '010-1234-1234',
   birth: '1994-03-02',
   image_url: '../../munetic_app/public/img/testImg.png',
 };
@@ -14,6 +15,7 @@ export const user2 = {
   name: '조올림',
   gender: Gender.Male,
   name_public: true,
+  phone_number: '010-5678-5678',
   birth: '1998-02-20',
   image_url: '../../munetic_app/public/img/testImg.png',
 };


### PR DESCRIPTION
### 개요
유저 아이디로 레슨 조회가 가능합니다.

### 작업 사항
findLessonsByUserId service를 작성하고 getUserLessons controller를 작성하였습니다.
/lesson/user/:id를 통해 접근 가능하게 만들었습니다.
swagger도 이에 맞춰서 수정하였습니다.

### 변경점
/lesson/user/:id에 userid와 query로 offset, limit을 넘겨주면 해당하는 레슨을 조회하여 되돌려줍니다.
또, getLessons와 getLessonsByUserId는 조건에 맞는 전체 레코드 개수도 반환하여 리턴하도록 하였습니다.

### 목적
페이지네이션을 위함입니다.
