### PR TITLE
[feat] admin 회원 정보 수정(회원 유형), 삭제 기능 구현 #135

### DIFF
--- a/munetic_admin/src/components/Grid/User/OverView.tsx
+++ b/munetic_admin/src/components/Grid/User/OverView.tsx
@@ -13,8 +13,7 @@ export default function OverView() {
       Api.deleteUser(userInfo.id)
         .then(() => {
           alert('삭제되었습니다.');
-          // window.location.replace(`admin/users/${userInfo.id}`);
-          navigate(`/users/${userInfo.id}`);
+          window.location.replace(`${userInfo.id}`);
         })
         .catch(err => alert(err.response.data));
     }

--- a/munetic_admin/src/components/Grid/User/OverView.tsx
+++ b/munetic_admin/src/components/Grid/User/OverView.tsx
@@ -1,15 +1,32 @@
 import styled, { css } from 'styled-components';
 import { useUser } from '../../../contexts/user';
 import Button from '../../Button';
+import { useNavigate } from 'react-router-dom';
+import * as Api from '../../../lib/api';
 
 export default function OverView() {
   const userInfo = useUser() as any;
+  const navigate = useNavigate();
+
+  const deleteUserHandler = () => {
+    if (window.confirm(`${userInfo.login_id} 유저를 삭제하시겠습니까?`)) {
+      Api.deleteUser(userInfo.id)
+        .then(() => {
+          alert('삭제되었습니다.');
+          navigate(`/users`);
+        })
+        .catch(err => alert(err.response.data));
+    }
+  };
+
   return (
     <>
       <UserImage url={userInfo.image_url} />
       <UserNickname>{userInfo.nickname}</UserNickname>
       <UserId>{userInfo.login_id}</UserId>
-      <CustomButton disabled={userInfo.deletedAt}>회원 삭제</CustomButton>
+      <CustomButton disabled={userInfo.deletedAt} onClick={deleteUserHandler}>
+        회원 삭제
+      </CustomButton>
     </>
   );
 }

--- a/munetic_admin/src/components/Grid/User/OverView.tsx
+++ b/munetic_admin/src/components/Grid/User/OverView.tsx
@@ -13,7 +13,8 @@ export default function OverView() {
       Api.deleteUser(userInfo.id)
         .then(() => {
           alert('삭제되었습니다.');
-          navigate(`/users`);
+          // window.location.replace(`admin/users/${userInfo.id}`);
+          navigate(`/users/${userInfo.id}`);
         })
         .catch(err => alert(err.response.data));
     }

--- a/munetic_admin/src/components/Grid/User/UserInfo.tsx
+++ b/munetic_admin/src/components/Grid/User/UserInfo.tsx
@@ -1,17 +1,63 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { useUser } from '../../../contexts/user';
 import Title from '../Common/Title';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import { useState } from 'react';
+import Button from '../../Button';
+import * as Api from '../../../lib/api';
 
 export default function UserInfo() {
   const userInfo = useUser() as any;
+  const [type, setType] = useState(userInfo.type);
+  const [edit, setEdit] = useState(false);
 
+  const handleEdit = () => {
+    setEdit(!edit);
+  };
+
+  const handleChange = (event: SelectChangeEvent) => {
+    setType(event.target.value);
+  };
+
+  const typeUpdate = () => {
+    Api.updateUserInfo(userInfo.id, { type }).then(() => {
+      window.location.replace(`${userInfo.id}`);
+    });
+  };
   return (
     <>
       <Title> 유저 정보 </Title>
-      <TextField>
-        <p>이름</p>
-        <div>{userInfo.name}</div>
-      </TextField>
+      <TextFields>
+        <TextField>
+          <p>이름</p>
+          <div>{userInfo.name}</div>
+        </TextField>
+        <TextField_>
+          <p>유형</p>
+          <Select
+            value={type}
+            onChange={handleChange}
+            autoWidth
+            inputProps={{ readOnly: edit ? false : true }}
+            sx={{ '& div': { m: 0, pt: 0.7 } }}
+          >
+            <MenuItem value={'Student'}>Student</MenuItem>
+            <MenuItem value={'Tutor'}>Tutor</MenuItem>
+          </Select>
+          <CustomButton disabled={!!userInfo.deletedAt} onClick={handleEdit}>
+            {edit ? '취소' : '편집'}
+          </CustomButton>
+          {edit && (
+            <CustomButton
+              disabled={userInfo.type === type}
+              onClick={typeUpdate}
+            >
+              저장
+            </CustomButton>
+          )}
+        </TextField_>
+      </TextFields>
       <TextFields>
         <TextField>
           <p>생년월일</p>
@@ -52,6 +98,7 @@ const TextFields = styled.div`
 `;
 
 const TextField = styled.div`
+  margin: auto 0;
   flex: 1;
   padding-top: 1rem;
   padding-left: 1rem;
@@ -64,6 +111,7 @@ const TextField = styled.div`
     width: 7rem;
   }
   & div {
+    margin: auto 0;
     padding-bottom: 0.3rem;
     font-size: 1.3rem;
     min-width: 10rem;
@@ -77,6 +125,7 @@ const TextField_ = styled.div`
   display: flex;
   width: 100%;
   & p {
+    margin-top: 0.5rem;
     border-left: 0.1rem solid grey;
     padding-left: 3rem;
     font-size: 1.3rem;
@@ -89,4 +138,19 @@ const TextField_ = styled.div`
     padding-bottom: 0.3rem;
     font-size: 1.3rem;
   }
+`;
+
+const CustomButton = styled(Button)`
+  width: 5rem;
+  height: auto;
+  padding: 0rem;
+  margin: 0 0 0 1rem;
+  background-color: rgb(82, 111, 255);
+  ${props =>
+    props.disabled &&
+    css`
+      background-color: rgb(140, 140, 140);
+    `}
+  border-radius: 0.5rem;
+  line-height: 1;
 `;

--- a/munetic_admin/src/components/Grid/User/UserInfo.tsx
+++ b/munetic_admin/src/components/Grid/User/UserInfo.tsx
@@ -125,7 +125,6 @@ const TextField_ = styled.div`
   display: flex;
   width: 100%;
   & p {
-    margin-top: 0.5rem;
     border-left: 0.1rem solid grey;
     padding-left: 3rem;
     font-size: 1.3rem;

--- a/munetic_admin/src/components/InputsContainers/AddAdminUser.tsx
+++ b/munetic_admin/src/components/InputsContainers/AddAdminUser.tsx
@@ -1,6 +1,7 @@
 import styled, { css } from 'styled-components';
 import { useState } from 'react';
 import { SelectChangeEvent } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
 
 import CustomInput from '../Inputs/CustomInput';
 import CustomPasswordInputs from '../Inputs/CustomPasswordInput';
@@ -8,11 +9,7 @@ import CustomSelect from '../Inputs/CustomSelect';
 import Button from '../Button';
 import * as Api from '../../lib/api';
 
-interface AdminUserProps {
-  rerender: () => void;
-}
-
-export function AddAdminUser({ rerender }: AdminUserProps) {
+export function AddAdminUser() {
   const [email, setEmail] = useState('');
   const [isValid, setIsValid] = useState(false);
   const [password, setPassword] = useState('1234');
@@ -20,6 +17,8 @@ export function AddAdminUser({ rerender }: AdminUserProps) {
   const [auth, setAuth] = useState('Admin');
   const [showPassword, setShowPassword] = useState(false);
   const [buttonText, setButtonText] = useState('중복');
+
+  const navigate = useNavigate();
 
   const checkEmail = () => {
     Api.doubleCheck(`email=${email}`)
@@ -37,7 +36,7 @@ export function AddAdminUser({ rerender }: AdminUserProps) {
     Api.createUser({ email, login_password: password, name, type: auth })
       .then(() => {
         alert('계정이 성공적으로 생성되었습니다.');
-        rerender();
+        window.location.replace('/admin/admin_users');
       })
       .catch(err => alert(`${err.response}`));
   };

--- a/munetic_admin/src/components/Login/Login.tsx
+++ b/munetic_admin/src/components/Login/Login.tsx
@@ -67,7 +67,7 @@ const LoginContainer = styled.div`
 
 const LoginCard = styled.div`
   width: 30rem;
-  height: 30vh;
+  height: 25rem;
   padding: 4rem 3.5rem 3.5rem 3.5rem;
   border-radius: 40px;
   background-color: #ecf0f3;

--- a/munetic_admin/src/lib/api.ts
+++ b/munetic_admin/src/lib/api.ts
@@ -46,6 +46,9 @@ export const getAdminUserList = async (page: number) => {
   return await instance.get(`user/admin?page=${page + 1}`);
 };
 
+export const getUserInfo = async (userId: number) => {
+  return await instance.get(`user/${userId}`);
+};
 export const deleteUser = async (userId: number) => {
   return await instance.delete(`user/${userId}`);
 };

--- a/munetic_admin/src/lib/api.ts
+++ b/munetic_admin/src/lib/api.ts
@@ -18,6 +18,14 @@ interface createUserProps {
   type: string;
 }
 
+interface editUserProps {
+  type?: string;
+  password?: string;
+  nickname?: string;
+  name?: string;
+  birth?: string;
+}
+
 export const login = async (loginInfo: LoginProps) => {
   return await instance.post('auth/login', loginInfo);
 };
@@ -65,4 +73,11 @@ export const getUserLessons = async (
   return await instance.get(
     `lesson/user/${userId}?offset=${offset}&limit=${limit}`,
   );
+};
+
+export const updateUserInfo = async (
+  userId: number,
+  userInfo: editUserProps,
+) => {
+  return await instance.patch(`user/${userId}`, userInfo);
 };

--- a/munetic_admin/src/lib/api.ts
+++ b/munetic_admin/src/lib/api.ts
@@ -46,6 +46,10 @@ export const getAdminUserList = async (page: number) => {
   return await instance.get(`user/admin?page=${page + 1}`);
 };
 
+export const deleteUser = async (userId: number) => {
+  return await instance.delete(`user/${userId}`);
+};
+
 export const getAllLessons = async (offset: number, limit: number) => {
   return await instance.get(`lesson?offset=${offset}&limit=${limit}`);
 };

--- a/munetic_admin/src/pages/AdminUserPage.tsx
+++ b/munetic_admin/src/pages/AdminUserPage.tsx
@@ -32,13 +32,6 @@ export default function AdminUserPage() {
     setPage(0);
   };
 
-  /**
-   * 데이터에 변동이 생겼을 시 다시 렌더링하는 이벤트
-   */
-  const handleReRender = () => {
-    setCount(count + 1);
-  };
-
   useEffect(() => {
     Api.getAdminUserList(page)
       .then(({ data }: any) => {
@@ -49,11 +42,11 @@ export default function AdminUserPage() {
         if (err.response) alert(err.response.data);
         navigate('/');
       });
-  }, [page, count]);
+  }, []);
 
   return (
     <>
-      <AddAdminUser rerender={handleReRender} />
+      <AddAdminUser />
       <MUITable
         page={page}
         count={count}

--- a/munetic_admin/src/pages/UserInfoPage.tsx
+++ b/munetic_admin/src/pages/UserInfoPage.tsx
@@ -1,5 +1,19 @@
 import CustomGrid from '../components/Grid/CustomGrid';
+import { useUserUpdate } from '../contexts/user';
+import { useLocation } from 'react-router-dom';
+import { useEffect } from 'react';
+import * as Api from '../lib/api';
 
 export default function UserInfoPage() {
+  const path = useLocation().pathname;
+  const setUser = useUserUpdate();
+
+  useEffect(() => {
+    const userId = parseInt(path.slice(7), 10);
+    Api.getUserInfo(userId).then(res => {
+      if (setUser) setUser(res.data.data);
+    });
+  });
+
   return <CustomGrid />;
 }

--- a/munetic_admin/src/pages/UserInfoPage.tsx
+++ b/munetic_admin/src/pages/UserInfoPage.tsx
@@ -13,7 +13,7 @@ export default function UserInfoPage() {
     Api.getUserInfo(userId).then(res => {
       if (setUser) setUser(res.data.data);
     });
-  });
+  }, []);
 
   return <CustomGrid />;
 }

--- a/munetic_express/src/controllers/admin/user.controller.ts
+++ b/munetic_express/src/controllers/admin/user.controller.ts
@@ -42,6 +42,21 @@ export const getAdminUserList: RequestHandler = async (req, res, next) => {
   }
 };
 
+export const getUserInfo: RequestHandler = async (req, res, next) => {
+  try {
+    if (!req.params.id) {
+      res.status(Status.BAD_REQUEST).send('유저 아이디가 없습니다.');
+    }
+    const userId = parseInt(req.params.id, 10);
+    const user = await UserService.findUserById(userId);
+    res
+      .status(Status.OK)
+      .json(new ResJSON('유저 프로필을 불러오는데 성공하였습니다.', user));
+  } catch (err) {
+    next(err);
+  }
+};
+
 export const doubleCheck: RequestHandler = async (req, res, next) => {
   try {
     const userList = await UserService.searchAllUser(req.query);

--- a/munetic_express/src/controllers/admin/user.controller.ts
+++ b/munetic_express/src/controllers/admin/user.controller.ts
@@ -48,7 +48,7 @@ export const getUserInfo: RequestHandler = async (req, res, next) => {
       res.status(Status.BAD_REQUEST).send('유저 아이디가 없습니다.');
     }
     const userId = parseInt(req.params.id, 10);
-    const user = await UserService.findUserById(userId);
+    const user = await UserService.findAllUserById(userId);
     res
       .status(Status.OK)
       .json(new ResJSON('유저 프로필을 불러오는데 성공하였습니다.', user));

--- a/munetic_express/src/controllers/admin/user.controller.ts
+++ b/munetic_express/src/controllers/admin/user.controller.ts
@@ -58,3 +58,28 @@ export const doubleCheck: RequestHandler = async (req, res, next) => {
     next(err);
   }
 };
+
+export const deleteUserByAdmin: RequestHandler = async (req, res, next) => {
+  try {
+    const userId = parseInt(req.params.id, 10);
+    const result = await UserService.deleteUser(userId);
+    if (result)
+      res
+        .status(Status.OK)
+        .json(new ResJSON('유저가 성공적으로 삭제되었습니다.', {}));
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const patchUserByAdmin: RequestHandler = async (req, res, next) => {
+  try {
+    const userId = parseInt(req.params.id, 10);
+    const user = await UserService.editUserById(userId, req.body);
+    res
+      .status(Status.OK)
+      .json(new ResJSON('유저 프로필을 성공적으로 수정하였습니다.', user));
+  } catch (err) {
+    next(err);
+  }
+};

--- a/munetic_express/src/routes/admin/user.routes.ts
+++ b/munetic_express/src/routes/admin/user.routes.ts
@@ -12,3 +12,13 @@ router.get(
   UserApi.getAdminUserList,
 );
 router.get('/check', passport.authenticate('jwt-admin'), UserApi.doubleCheck);
+router.delete(
+  '/:id',
+  passport.authenticate('jwt-admin'),
+  UserApi.deleteUserByAdmin,
+);
+router.patch(
+  '/:id',
+  passport.authenticate('jwt-admin'),
+  UserApi.patchUserByAdmin,
+);

--- a/munetic_express/src/routes/admin/user.routes.ts
+++ b/munetic_express/src/routes/admin/user.routes.ts
@@ -12,13 +12,14 @@ router.get(
   UserApi.getAdminUserList,
 );
 router.get('/check', passport.authenticate('jwt-admin'), UserApi.doubleCheck);
-router.delete(
-  '/:id',
-  passport.authenticate('jwt-admin'),
-  UserApi.deleteUserByAdmin,
-);
+router.get('/:id', passport.authenticate('jwt-admin'), UserApi.getUserInfo);
 router.patch(
   '/:id',
   passport.authenticate('jwt-admin'),
   UserApi.patchUserByAdmin,
+);
+router.delete(
+  '/:id',
+  passport.authenticate('jwt-admin'),
+  UserApi.deleteUserByAdmin,
 );

--- a/munetic_express/src/service/lesson.service.ts
+++ b/munetic_express/src/service/lesson.service.ts
@@ -263,6 +263,7 @@ const lessonQueryOptionsforAdmin: FindOptions = {
         'gender',
         'image_url',
       ],
+      paranoid: false,
     },
   ],
 };

--- a/munetic_express/src/service/user.service.ts
+++ b/munetic_express/src/service/user.service.ts
@@ -21,6 +21,18 @@ export const createUser = async (userInfo: User) => {
   return dataJSON;
 };
 
+export const deleteUser = async (userId: number) => {
+  const user = await User.findOne({
+    where: {
+      id: userId,
+    },
+  });
+  if (!user)
+    throw new ErrorResponse(Status.BAD_REQUEST, '유효하지 않은 유저 id입니다.');
+  await user.destroy();
+  return true;
+};
+
 export const searchAllUser = async (userInfo: IsearchUser) => {
   const data = await User.findAll({
     where: {

--- a/munetic_express/src/service/user.service.ts
+++ b/munetic_express/src/service/user.service.ts
@@ -153,3 +153,18 @@ export const editUserById = async (
   }
   return newUserProfile as Promise<User>;
 };
+
+export const findAllUserById = async (id: number) => {
+  const user = await User.findOne({
+    where: { id: id },
+    attributes: { exclude: ['login_password'] },
+    paranoid: false,
+  });
+  if (user === null) {
+    throw new ErrorResponse(
+      Status.BAD_REQUEST,
+      '유효하지 않은 유저 아이디입니다.',
+    );
+  }
+  return user;
+};

--- a/munetic_express/src/swagger.yml
+++ b/munetic_express/src/swagger.yml
@@ -738,6 +738,80 @@ paths:
             example: 'Unauthorized'
 
   # admin user
+  /admin/user/{id}:
+    patch:
+      tags:
+        - Admin User
+      summary: update user information by user account
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: header
+          name: Authorization
+          required: true
+          type: string
+        - in: body
+          name: body
+          schema:
+            type: object
+            properties:
+              type:
+                enum:
+                  - Student
+                  - Tutor
+      responses:
+        '200':
+          description: SUCCESS
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: '유저 프로필을 성공적으로 수정하였습니다.'
+              data:
+                $ref: '#/definitions/User'
+        '400':
+          description: Unauthorized
+          schema:
+            type: string
+            example: '유효하지 않은 유저입니다.'
+
+    delete:
+      tags:
+        - Admin User
+      summary: soft delete user by admin account
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: header
+          name: Authorization
+          required: true
+          type: string
+        - in: path
+          required: true
+          type: string
+          name: id
+      responses:
+        '200':
+          description: OK
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: '유저가 성공적으로 삭제되었습니다.'
+              data:
+                type: object
+        '400':
+          description: Bad_Request
+          schema:
+            type: string
+            example: '유효하지 않은 유저 아이디 입니다.'
+
   /admin/user/check:
     get:
       tags:

--- a/munetic_express/src/swagger.yml
+++ b/munetic_express/src/swagger.yml
@@ -739,6 +739,40 @@ paths:
 
   # admin user
   /admin/user/{id}:
+    get:
+      tags:
+        - Admin User
+      summary: get specific user information by user account
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - in: header
+          name: Authorization
+          required: true
+          type: string
+        - in: path
+          required: true
+          type: string
+          name: id
+      responses:
+        '200':
+          description: 'request success'
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: 유저 프로필을 불러오는데 성공하였습니다.
+              data:
+                $ref: '#/definitions/User'
+        '400':
+          description: 'Bad Request'
+          schema:
+            type: string
+            example: '유저 아이디가 없습니다. or 유효하지 않은 유저 아이디입니다.'
+
     patch:
       tags:
         - Admin User
@@ -752,6 +786,10 @@ paths:
           name: Authorization
           required: true
           type: string
+        - in: path
+          required: true
+          type: string
+          name: id
         - in: body
           name: body
           schema:


### PR DESCRIPTION
### 개요
[feat] admin 회원 정보 수정(회원 유형), 삭제 기능 구현 #135

### 작업 사항
- `admin/user/:id` get/patch/delete api 개발
-  admin 클라이언트와 연결

### 변경점

### 목적

### 스크린샷 (optional)
<img width="1436" alt="스크린샷 2022-01-09 오전 2 12 48" src="https://user-images.githubusercontent.com/50102773/148653364-03533c8e-8d93-4ab9-b4ce-af73e751a201.png">