### PR TITLE
feat: #139 튜터 계정만 레슨 등록 가능하게 변경, 선생님 가입 추가, 로그인 상태에서만 프로필 메뉴 이동하게 변경

### DIFF
--- a/munetic_app/src/components/Home.tsx
+++ b/munetic_app/src/components/Home.tsx
@@ -51,6 +51,9 @@ export default function Home() {
   const onClickSignup = () => {
     navigate('/auth/register');
   };
+  const onClickSignupTutor = () => {
+    navigate('/auth/register?tutor=tutor');
+  };
 
   const onClickProfileView = async () => {
     try {
@@ -96,13 +99,20 @@ export default function Home() {
           <Button to="/lesson/category">레슨 찾기</Button>
         </div>
         <div className="homeRegisterButton">
-          <Button to="/lesson/manage">레슨 등록</Button>
+          {loggedUser ? (
+            <Button to="/lesson/manage">레슨 등록</Button>
+          ) : (
+            <Button to="/auth/register?tutor=tutor">
+              레슨 등록(선생님 계정 필요)
+            </Button>
+          )}
         </div>
       </div>
       <button onClick={loggedUser ? onClickLogout : onClickLogin}>
         {loggedUser ? '로그아웃' : '로그인'}
       </button>
-      <button onClick={onClickSignup}>회원가입</button>
+      <button onClick={onClickSignup}>학생 회원가입</button>
+      <button onClick={onClickSignupTutor}>튜터 회원가입</button>
       <button onClick={onClickProfileView}>내 프로필 조회</button>
       <button onClick={onClickProfileEdit}>내 프로필 수정</button>
       <button onClick={onClickProfileViewOthers}>다른 사람 프로필 조회</button>

--- a/munetic_app/src/components/auth/Login.tsx
+++ b/munetic_app/src/components/auth/Login.tsx
@@ -81,7 +81,7 @@ export default function Login() {
         } catch (e) {
           console.log(e, 'localStorage is not working');
         }
-        navigate('/');
+        navigate(-1);
       } catch (e) {
         setShowErrorMessage(true);
         console.log(e, '로그인 실패');

--- a/munetic_app/src/components/auth/Register.tsx
+++ b/munetic_app/src/components/auth/Register.tsx
@@ -6,9 +6,10 @@ import { InputBox } from '../common/Input';
 import Select from '../common/Select';
 import * as AuthAPI from '../../lib/api/auth';
 import Contexts from '../../context/Contexts';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { dayList, monthList, yearList } from '../../lib/staticData';
 import { Account } from '../../types/enums';
+import client from '../../lib/api/client';
 
 const Container = styled.form`
   margin: 100px 30px 30px 30px;
@@ -94,11 +95,14 @@ const StyledButton = styled(Button)`
 `;
 
 export default function Register() {
+  const [getParams] = useSearchParams();
+  const tutorParam = getParams.get('tutor');
+
   const { state, actions } = useContext(Contexts);
   const [registerInfo, setRegisterInfo] = useState({
     login_id: '',
     login_password: '',
-    type: Account.Student,
+    type: tutorParam ? Account.Tutor : Account.Student,
     nickname: '',
     name: '',
     email: '',
@@ -216,6 +220,8 @@ export default function Register() {
     if (validateSignupForm()) {
       try {
         await AuthAPI.signup(registerInfo);
+        client.defaults.headers.common['Authorization'] = '';
+        localStorage.removeItem('user');
         navigate('/auth/login');
       } catch (e) {
         console.log(e, '회원가입 실패');

--- a/munetic_app/src/components/common/BottomMenu.tsx
+++ b/munetic_app/src/components/common/BottomMenu.tsx
@@ -27,7 +27,7 @@ export default function BottomMenu() {
   const onChangeMenu = (event: any, newValue: number) => {
     setValue(newValue);
     const paths = ['/', '/search', '/profile/manage', '/bookmark', '/setting'];
-    navigate(paths[newValue], { replace: true });
+    navigate(paths[newValue]);
   };
 
   useEffect(() => {

--- a/munetic_app/src/components/profile/ManageProfile.tsx
+++ b/munetic_app/src/components/profile/ManageProfile.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from 'react';
 import { UserDataType } from '../../types/userData';
 import * as ProfileAPI from '../../lib/api/profile';
 import Button from '../common/Button';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 const Container = styled.div`
   margin: 30px 0;
@@ -77,7 +77,7 @@ const Separater = styled.div`
 `;
 
 export default function ManageProfile() {
-  const userLogged = localStorage.getItem('user');
+  const navigate = useNavigate();
   const [userData, setUserData] = useState<UserDataType>();
 
   useEffect(() => {
@@ -87,11 +87,10 @@ export default function ManageProfile() {
         setUserData(userProfile.data.data);
       } catch (e) {
         console.log(e, '내 프로필을 불러오지 못했습니다.');
+        navigate('/auth/login');
       }
     }
-    if (userLogged) {
-      getMyProfile();
-    }
+    getMyProfile();
   }, []);
 
   return (
@@ -102,7 +101,7 @@ export default function ManageProfile() {
         <Container>
           {userData.type === 'Student' ? (
             <ChangeTypeButton>
-              <Link to="/auth/register">선생님 계정으로 변경</Link>
+              <Link to="/auth/register?tutor=tutor">선생님 계정으로 변경</Link>
             </ChangeTypeButton>
           ) : (
             ''


### PR DESCRIPTION
### 개요
튜터 계정만 레슨 등록 가능하게 변경, 선생님 가입 추가, 로그인 상태에서만 프로필 메뉴 이동하게 변경
### 작업 사항
- 홈 화면의 레슨 등록 버튼 클릭시 계정 타입에 따라 다르게 이동하도록 변경
-- 튜터 계정 : 레슨 등록 페이지
-- 비로그인, 학생 계정 : 튜터 회원가입 페이지
- 로그인 시 홈화면으로 이동하게 하던 것을 한 페이지 이전 화면으로 이동하게 변경
- 회원가입 페이지 이동시 쿼리에 tutor 있으면 튜터 회원가입 없으면 학생 회원가입
- 회원가입 성공 시 기존 로그인 되어있던 것 로그아웃 처리
- 하단 메뉴바 이동시 navigate replace옵션 삭제
- 프로필 메뉴 이동시 비로그인 상태면 로그인 페이지로 이동하게 변경
### 변경점
- 선생님 계정으로 가입 가능
- 레슨 등록이 계정 별로 구분됩니다.
### 목적
선생님 계정으로 가입하기 위함
ux상향
### 스크린샷 (optional)
