### PR TITLE
[feat] 어드민 비밀번호 변경 기능 #142

### DIFF
--- a/munetic_admin/src/components/AdminUser/AddAdminUser.tsx
+++ b/munetic_admin/src/components/AdminUser/AddAdminUser.tsx
@@ -36,7 +36,7 @@ export function AddAdminUser() {
     Api.createUser({ email, login_password: password, name, type: auth })
       .then(() => {
         alert('계정이 성공적으로 생성되었습니다.');
-        window.location.replace('/admin/admin_users');
+        navigate(0);
       })
       .catch(err => alert(`${err.response}`));
   };

--- a/munetic_admin/src/components/Auth/Login.tsx
+++ b/munetic_admin/src/components/Auth/Login.tsx
@@ -21,7 +21,7 @@ export default function Login() {
         if (setLogin) setLogin(true);
       })
       .catch(err => {
-        if (err.respose) alert(err.response.data);
+        if (err.response) alert(err.response.data);
       });
   };
 

--- a/munetic_admin/src/components/Auth/PasswordChange.tsx
+++ b/munetic_admin/src/components/Auth/PasswordChange.tsx
@@ -1,0 +1,134 @@
+import styled, { css } from 'styled-components';
+import { useState } from 'react';
+import Button from '../Button';
+import CustomPasswordInputs from '../Inputs/CustomPasswordInput';
+import * as Api from '../../lib/api';
+import { useLoginUpdate } from '../../contexts/login';
+
+export default function PasswordChange() {
+  const setLogin = useLoginUpdate();
+  const [password, setPassword] = useState('');
+  const [isValid, setIsValid] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [newPassword, setNewPassword] = useState('');
+
+  const loginHandler = () => {
+    const login_id = JSON.parse(localStorage.getItem('user') as string);
+    Api.login({
+      login_id: login_id,
+      login_password: password,
+    })
+      .then(() => setIsValid(true))
+      .catch(err => {
+        if (err.response) alert(err.response.data);
+        else alert(err.message);
+      });
+  };
+
+  const updatePasswordHandler = () => {
+    Api.updatePassword({ login_password: newPassword })
+      .then(() => {
+        alert(
+          '비밀번호가 성공적으로 변경되었습니다. 새 비밀번호로 다시 로그인 해주세요.',
+        );
+        Api.logout()
+          .then(res => {
+            Api.instance.defaults.headers.common['Authorization'] = '';
+            localStorage.removeItem('user');
+            if (setLogin) setLogin(false);
+          })
+          .catch(err => console.log(err.response));
+      })
+      .catch(err => alert(err.response.data));
+  };
+  return (
+    <PasswordCard>
+      {!isValid ? (
+        <>
+          <Fields>
+            <p>현재 비밀번호를 입력해주세요.</p>
+            <CustomPasswordInputs
+              width="27rem"
+              fontSize="1.5rem"
+              showPassword={showPassword}
+              clickEvent={() => setShowPassword(!showPassword)}
+              value={password}
+              onChangeEvent={e => setPassword(e.target.value)}
+            />
+          </Fields>
+          <CustomButton disabled={!password} onClick={loginHandler}>
+            확인
+          </CustomButton>
+        </>
+      ) : (
+        <>
+          <Fields>
+            <p>새 비밀번호를 입력해주세요.</p>
+            <CustomPasswordInputs
+              width="27rem"
+              fontSize="1.5rem"
+              showPassword={showPassword}
+              clickEvent={() => setShowPassword(!showPassword)}
+              value={newPassword}
+              onChangeEvent={e => setNewPassword(e.target.value)}
+            />
+          </Fields>
+          <CustomButton disabled={!newPassword} onClick={updatePasswordHandler}>
+            변경
+          </CustomButton>
+        </>
+      )}
+    </PasswordCard>
+  );
+}
+
+const PasswordCard = styled.div`
+  margin: 10rem auto;
+  width: 30rem;
+  height: 25rem;
+  padding: 3rem 3.5rem 3.5rem 3.5rem;
+  border-radius: 40px;
+  background-color: #ecf0f3;
+  box-shadow: 1.3rem 1rem 1.3rem #cbced1, -1.3rem -1.3rem 2rem #fff;
+`;
+
+const Fields = styled.div`
+  margin-top: 3rem;
+  width: 100%;
+  padding: 1.5rem 0.5rem 0.5rem 0.5rem;
+  & p {
+    font-size: 1.5rem;
+    padding: 0.5rem;
+    margin-bottom: 1rem;
+  }
+`;
+
+const InputContainer = styled.div`
+  &:not(:last-child) {
+  }
+  margin-bottom: 2rem;
+  border-radius: 2.5rem;
+  box-shadow: inset 0.3rem 0.3rem 0.3rem #cbced1,
+    inset -0.1rem -0.1rem 0.1rem #fff;
+  > input {
+    border: none;
+    outline: none;
+    background: transparent;
+    color: #555;
+    font-size: 1.5rem;
+    padding: 1rem 0.5rem 1rem 2rem;
+  }
+`;
+
+const CustomButton = styled(Button)`
+  display: block;
+  margin-top: 1rem;
+  margin-left: 2rem;
+  width: 85%;
+  background-color: rgb(82, 111, 255);
+  ${props =>
+    props.disabled &&
+    css`
+      background-color: rgb(140, 140, 140);
+    `}
+`;

--- a/munetic_admin/src/components/Info/Lesson/LessonGrid.tsx
+++ b/munetic_admin/src/components/Info/Lesson/LessonGrid.tsx
@@ -7,16 +7,18 @@ import LessonInfo from './LessonInfo';
 import WriterInfo from './WriterInfo';
 import Button from '../../Button';
 import * as Api from '../../../lib/api';
+import { useNavigate } from 'react-router-dom';
 
 export default function LessonGrid() {
   const info = useInfo() as any;
+  const navigate = useNavigate();
 
   const deleteLesson = () => {
     if (window.confirm(`이 게시물을 삭제하시겠습니까?`)) {
       Api.deleteLesson(info.id)
         .then(() => {
           alert('삭제되었습니다.');
-          window.location.replace(`${info.id}`);
+          navigate(0);
         })
         .catch(err => alert(err.response.data));
     }

--- a/munetic_admin/src/components/Info/User/OverView.tsx
+++ b/munetic_admin/src/components/Info/User/OverView.tsx
@@ -2,16 +2,18 @@ import styled, { css } from 'styled-components';
 import { useInfo } from '../../../contexts/info';
 import Button from '../../Button';
 import * as Api from '../../../lib/api';
+import { useNavigate } from 'react-router-dom';
 
 export default function OverView() {
   const info = useInfo() as any;
+  const navigate = useNavigate();
 
   const deleteUserHandler = () => {
     if (window.confirm(`${info.login_id} 유저를 삭제하시겠습니까?`)) {
       Api.deleteUser(info.id)
         .then(() => {
           alert('삭제되었습니다.');
-          window.location.replace(`${info.id}`);
+          navigate(0);
         })
         .catch(err => alert(err.response.data));
     }

--- a/munetic_admin/src/components/Inputs/CustomPasswordInput.tsx
+++ b/munetic_admin/src/components/Inputs/CustomPasswordInput.tsx
@@ -15,6 +15,7 @@ interface PasswordInput {
   clickEvent: () => void;
   value: string;
   onChangeEvent: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  placeholder?: string;
 }
 
 export default function CustomPasswordInputs({
@@ -24,6 +25,7 @@ export default function CustomPasswordInputs({
   clickEvent,
   value,
   onChangeEvent,
+  placeholder,
 }: PasswordInput) {
   return (
     <FormControl sx={{ m: 1, width }} variant="standard">
@@ -31,6 +33,7 @@ export default function CustomPasswordInputs({
         Password
       </InputLabel>
       <Input
+        placeholder={placeholder}
         sx={{ fontSize }}
         id="password"
         type={showPassword ? 'text' : 'password'}

--- a/munetic_admin/src/components/Menu/AvatarDropBox.tsx
+++ b/munetic_admin/src/components/Menu/AvatarDropBox.tsx
@@ -1,8 +1,0 @@
-import styled from 'styled-components';
-
-export default function AvartarDropBox() {}
-
-const dropbox = styled.div`
-  width: 10rem;
-  background-color: grey;
-`;

--- a/munetic_admin/src/components/Menu/Menu.tsx
+++ b/munetic_admin/src/components/Menu/Menu.tsx
@@ -6,7 +6,6 @@ import { useState } from 'react';
 import { useLoginUpdate } from '../../contexts/login';
 import { instance } from '../../lib/api';
 import * as Api from '../../lib/api';
-import { ClassNames } from '@emotion/react';
 
 export default function Menu() {
   const setLogin = useLoginUpdate();
@@ -25,7 +24,7 @@ export default function Menu() {
         localStorage.removeItem('user');
         if (setLogin) setLogin(false);
       })
-      .catch(err => console.log(err.response));
+      .catch(err => alert(err.response.data));
   }
 
   function stringAvatar(name: string) {
@@ -65,7 +64,12 @@ export default function Menu() {
           {isSeen && (
             <Dropbox>
               <ul>
-                <DropboxContent onClick={logoutHandler}>logout</DropboxContent>
+                <DropboxContent onClick={logoutHandler}>
+                  로그아웃
+                </DropboxContent>
+                <Link to="/auth/password">
+                  <DropboxContent>비밀번호 변경</DropboxContent>
+                </Link>
               </ul>
             </Dropbox>
           )}
@@ -194,5 +198,9 @@ const DropboxContent = styled.li`
   font-size: 1.3rem;
   color: white;
   padding: 1rem;
+  margin: 0.2rem;
   text-align: center;
+  &:not(:last-child) {
+    border-bottom: 0.1rem solid white;
+  }
 `;

--- a/munetic_admin/src/components/Routing.tsx
+++ b/munetic_admin/src/components/Routing.tsx
@@ -8,6 +8,7 @@ import AdminUserPage from '../pages/AdminUserPage';
 import AdminUserInfoPage from '../pages/AdminUserInfoPage';
 import InfoProvider from '../contexts/info';
 import UserInfoPage from '../pages/UserInfoPage';
+import PasswordChangePage from '../pages/PasswordChangePage';
 
 export default function Routing() {
   return (
@@ -21,6 +22,7 @@ export default function Routing() {
           <Route path="/admin_users/:id" element={<AdminUserInfoPage />} />
           <Route path="/lessons" element={<LessonListPage />} />
           <Route path="/lessons/:id" element={<LessonInfoPage />} />
+          <Route path="/auth/password" element={<PasswordChangePage />} />
         </Routes>
       </InfoProvider>
     </RoutesContainer>

--- a/munetic_admin/src/lib/api.ts
+++ b/munetic_admin/src/lib/api.ts
@@ -88,3 +88,10 @@ export const getLesson = async (lessonId: number) => {
 export const deleteLesson = async (lessonId: number) => {
   return await instance.delete(`lesson/${lessonId}`);
 };
+
+interface passwordProps {
+  login_password: string;
+}
+export const updatePassword = async (newPassword: passwordProps) => {
+  return await instance.patch('auth/password', newPassword);
+};

--- a/munetic_admin/src/pages/LoginPage.tsx
+++ b/munetic_admin/src/pages/LoginPage.tsx
@@ -1,4 +1,4 @@
-import Login from '../components/Login/Login';
+import Login from '../components/Auth/Login';
 
 export default function LoginPage() {
   return <Login></Login>;

--- a/munetic_admin/src/pages/PasswordChangePage.tsx
+++ b/munetic_admin/src/pages/PasswordChangePage.tsx
@@ -1,0 +1,5 @@
+import PasswordChange from '../components/Auth/PasswordChange';
+
+export default function PasswordChangePage() {
+  return <PasswordChange />;
+}

--- a/munetic_express/src/controllers/admin/auth.controller.ts
+++ b/munetic_express/src/controllers/admin/auth.controller.ts
@@ -62,3 +62,14 @@ export const refresh: RequestHandler = async (req, res, next) => {
     next(err);
   }
 };
+
+export const updatePassword: RequestHandler = async (req, res, next) => {
+  try {
+    let { login_password } = req.body;
+    login_password = bcrypt.hashSync(login_password, 10);
+    await UserService.editUserById(req.user!.id, { login_password });
+    res.status(Status.OK).json(new ResJSON('비밀번호가 변경되었습니다.', {}));
+  } catch (err) {
+    next(err);
+  }
+};

--- a/munetic_express/src/routes/admin/auth.routes.ts
+++ b/munetic_express/src/routes/admin/auth.routes.ts
@@ -9,3 +9,8 @@ router.post('/signup', passport.authenticate('jwt-admin'), Auth.signup);
 router.post('/login', Auth.login);
 router.get('/logout', passport.authenticate('jwt-admin'), Auth.logout);
 router.get('/refresh', passport.authenticate('jwtRe-admin'), Auth.refresh);
+router.patch(
+  '/password',
+  passport.authenticate('jwt-admin'),
+  Auth.updatePassword,
+);

--- a/munetic_express/src/service/user.service.ts
+++ b/munetic_express/src/service/user.service.ts
@@ -127,6 +127,7 @@ export interface NewProfileInfoType {
   phone_public?: boolean;
   image_url?: string | null;
   introduction?: string | null;
+  login_password?: string | null;
 }
 
 export const editUserById = async (

--- a/munetic_express/src/swagger.yml
+++ b/munetic_express/src/swagger.yml
@@ -737,6 +737,41 @@ paths:
             type: string
             example: 'Unauthorized'
 
+  /admin/auth/password:
+    patch:
+      tags:
+        - Admin Auth
+      summary: update password
+      parameters:
+        - in: header
+          name: Authorization
+          required: true
+          type: string
+        - in: body
+          name: body
+          required: true
+          schema:
+            type: object
+            properties:
+              login_password:
+                type: string
+      responses:
+        '200':
+          description: 'Login success'
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: '비밀번호가 변경되었습니다.'
+              data:
+                type: object
+        '400':
+          description: 'Bad Request'
+          schema:
+            type: string
+            example: '유효하지 않은 유저 아이디입니다.'
+
   # admin user
   /admin/user/{id}:
     get:


### PR DESCRIPTION
### 개요
[feat] 어드민 비밀번호 변경 기능 #142

### 작업 사항
- express : updatePasword api 개발
- admin: password 변경 뷰 개발 및 api 연결

fix
- admin 요청 응답 후 페이지 자동 리로드를 위해 사용한 window.location이 proxy서버에서 작동하지 않는것을 알게됨
- 리액트 라우터 돔 훅을 써서 navigate(0)으로 교체

### 변경점

### 목적

### 스크린샷 (optional)
![Jan-09-2022 22-59-46](https://user-images.githubusercontent.com/50102773/148685706-2489052e-f266-40a2-96e5-7cd34a8f75d8.gif)

