### PR TITLE
style:express #146 organize jwtauthentication logic

### DIFF
--- a/munetic_express/src/modules/jwt.admin.strategy.ts
+++ b/munetic_express/src/modules/jwt.admin.strategy.ts
@@ -26,6 +26,8 @@ export const JwtAdminAccessStrategy = () =>
 export const JwtAdminRefreshStrategy = () =>
   new Strategy(refreshOpts, JwtAdminStrategyCallback);
 
-passport.serializeUser(function (user, done) {
-  done(null, user);
-});
+export const jwtAdminAuth = () =>
+  passport.authenticate('jwt-admin', { session: false });
+
+export const jwtReAdminAuth = () =>
+  passport.authenticate('jwtRefresh-admin', { session: false });

--- a/munetic_express/src/modules/jwt.local.strategy.ts
+++ b/munetic_express/src/modules/jwt.local.strategy.ts
@@ -50,6 +50,7 @@ export const JwtAccessStrategy = () =>
 export const JwtRefreshStrategy = () =>
   new Strategy(refreshOpts, JwtStrategyCallback);
 
-passport.serializeUser(function (user, done) {
-  done(null, user);
-});
+export const jwtAuth = () => passport.authenticate('jwt', { session: false });
+
+export const jwtReAuth = () =>
+  passport.authenticate('jwtRefresh', { session: false });

--- a/munetic_express/src/routes/admin/auth.routes.ts
+++ b/munetic_express/src/routes/admin/auth.routes.ts
@@ -1,16 +1,12 @@
 import { Router } from 'express';
 import * as Auth from '../../controllers/admin/auth.controller';
-import passport from 'passport';
+import { jwtAdminAuth, jwtReAdminAuth } from '../../modules/jwt.admin.strategy';
 
 export const path = '/auth';
 export const router = Router();
 
-router.post('/signup', passport.authenticate('jwt-admin'), Auth.signup);
+router.post('/signup', jwtAdminAuth(), Auth.signup);
 router.post('/login', Auth.login);
-router.get('/logout', passport.authenticate('jwt-admin'), Auth.logout);
-router.get('/refresh', passport.authenticate('jwtRe-admin'), Auth.refresh);
-router.patch(
-  '/password',
-  passport.authenticate('jwt-admin'),
-  Auth.updatePassword,
-);
+router.get('/logout', jwtAdminAuth(), Auth.logout);
+router.get('/refresh', jwtReAdminAuth(), Auth.refresh);
+router.patch('/password', jwtAdminAuth(), Auth.updatePassword);

--- a/munetic_express/src/routes/admin/lesson.routes.ts
+++ b/munetic_express/src/routes/admin/lesson.routes.ts
@@ -1,18 +1,12 @@
 import { Router } from 'express';
 import * as lesson from '../../controllers/admin/lesson.controller';
 import passport from 'passport';
+import { jwtAdminAuth } from '../../modules/jwt.admin.strategy';
 
 export const path = '/lesson';
 export const router = Router();
 
-router.get('/', passport.authenticate('jwt-admin'), lesson.getAllLessons);
-router.get(
-  '/:id',
-  /*passport.authenticate('jwt-admin'),*/ lesson.getLessonById,
-);
-router.delete('/:id', passport.authenticate('jwt-admin'), lesson.deleteLesson);
-router.get(
-  '/user/:id',
-  passport.authenticate('jwt-admin'),
-  lesson.getUserLessons,
-);
+router.get('/', jwtAdminAuth(), lesson.getAllLessons);
+router.get('/:id', jwtAdminAuth(), lesson.getLessonById);
+router.delete('/:id', jwtAdminAuth(), lesson.deleteLesson);
+router.get('/user/:id', jwtAdminAuth(), lesson.getUserLessons);

--- a/munetic_express/src/routes/admin/user.routes.ts
+++ b/munetic_express/src/routes/admin/user.routes.ts
@@ -1,25 +1,13 @@
 import { Router } from 'express';
-import passport from 'passport';
 import * as UserApi from '../../controllers/admin/user.controller';
+import { jwtAdminAuth } from '../../modules/jwt.admin.strategy';
 
 export const path = '/user';
 export const router = Router();
 
-router.get('/app', passport.authenticate('jwt-admin'), UserApi.getAppUserList);
-router.get(
-  '/admin',
-  passport.authenticate('jwt-admin'),
-  UserApi.getAdminUserList,
-);
-router.get('/check', passport.authenticate('jwt-admin'), UserApi.doubleCheck);
-router.get('/:id', passport.authenticate('jwt-admin'), UserApi.getUserInfo);
-router.patch(
-  '/:id',
-  passport.authenticate('jwt-admin'),
-  UserApi.patchUserByAdmin,
-);
-router.delete(
-  '/:id',
-  passport.authenticate('jwt-admin'),
-  UserApi.deleteUserByAdmin,
-);
+router.get('/app', jwtAdminAuth(), UserApi.getAppUserList);
+router.get('/admin', jwtAdminAuth(), UserApi.getAdminUserList);
+router.get('/check', jwtAdminAuth(), UserApi.doubleCheck);
+router.get('/:id', jwtAdminAuth(), UserApi.getUserInfo);
+router.patch('/:id', jwtAdminAuth(), UserApi.patchUserByAdmin);
+router.delete('/:id', jwtAdminAuth(), UserApi.deleteUserByAdmin);

--- a/munetic_express/src/routes/auth.routes.ts
+++ b/munetic_express/src/routes/auth.routes.ts
@@ -1,12 +1,13 @@
 import { Router } from 'express';
 import * as Auth from '../controllers/auth.controller';
 import passport from 'passport';
+import { jwtAuth, jwtReAuth } from '../modules/jwt.local.strategy';
 
 export const path = '/auth';
 export const router = Router();
 
 router.post('/login', Auth.login);
-router.get('/logout', passport.authenticate('jwt'), Auth.logout);
+router.get('/logout', jwtAuth(), Auth.logout);
 router.post('/signup', Auth.signup);
-router.get('/refresh', passport.authenticate('jwtRe'), Auth.refresh);
+router.get('/refresh', jwtReAuth(), Auth.refresh);
 router.get('/signup/user', Auth.isValidInfo);

--- a/munetic_express/src/routes/index.ts
+++ b/munetic_express/src/routes/index.ts
@@ -22,11 +22,11 @@ import {
 
 passport.use('local', LocalStrategy());
 passport.use('jwt', JwtAccessStrategy());
-passport.use('jwtRe', JwtRefreshStrategy());
+passport.use('jwtRefresh', JwtRefreshStrategy());
 
 passport.use('admin', AdminStrategy());
 passport.use('jwt-admin', JwtAdminAccessStrategy());
-passport.use('jwtRe-admin', JwtAdminRefreshStrategy());
+passport.use('jwtRefresh-admin', JwtAdminRefreshStrategy());
 
 router.use(auth.path, auth.router);
 router.use(user.path, user.router);

--- a/munetic_express/src/routes/user.routes.ts
+++ b/munetic_express/src/routes/user.routes.ts
@@ -1,17 +1,12 @@
 import { Router } from 'express';
-import passport from 'passport';
 import * as UserAPI from '../controllers/user.controller';
 import * as storage from '../modules/imgCreateMiddleware.ts';
+import { jwtAuth } from '../modules/jwt.local.strategy';
 
 export const path = '/user';
 export const router = Router();
 
-router.get('/', passport.authenticate('jwt'), UserAPI.getMyProfile);
-router.patch('/', passport.authenticate('jwt'), UserAPI.editUserProfile);
+router.get('/', jwtAuth(), UserAPI.getMyProfile);
+router.patch('/', jwtAuth(), UserAPI.editUserProfile);
 router.get('/:id', UserAPI.getUserProfile);
-router.post(
-  '/image',
-  passport.authenticate('jwt'),
-  storage.imgUpload,
-  UserAPI.createProfileImg,
-);
+router.post('/image', jwtAuth(), storage.imgUpload, UserAPI.createProfileImg);


### PR DESCRIPTION
### 개요
style:express #146 organize jwtauthentication logic

jwt 인증 미들웨어 로직 수정

### 작업 사항
session 기반 sreializeUser() 함수를 제거하고 미들웨어 옵션으로 {session:false}를 추가

### 변경점
모든 미들웨어에 session:false를 넣으니 긴 코드가 계속 반복되는게 비효율적
jwt 모듈 파일에 passport.authenticate(sdfsdfs, {session:false}) 를 리턴하는 함수를 생성해서 함수를 미들웨어로 사용하는 것으로 변경

### 목적

### 스크린샷 (optional)
