### PR TITLE
fix:express #151 fix refresh api logic

### DIFF
--- a/munetic_express/src/controllers/admin/auth.controller.ts
+++ b/munetic_express/src/controllers/admin/auth.controller.ts
@@ -55,8 +55,6 @@ export const signup: RequestHandler = async (req, res, next) => {
 export const refresh: RequestHandler = async (req, res, next) => {
   try {
     const accessToken = await jwt.accessToken(req.user);
-    const { token, cookieOptions } = await jwt.refreshToken(req.user);
-    res.cookie('refreshToken', token, cookieOptions);
     res.status(Status.OK).json(new ResJSON('request success', accessToken));
   } catch (err) {
     next(err);

--- a/munetic_express/src/controllers/auth.controller.ts
+++ b/munetic_express/src/controllers/auth.controller.ts
@@ -61,8 +61,6 @@ export const signup: RequestHandler = async (req, res, next) => {
 export const refresh: RequestHandler = async (req, res, next) => {
   try {
     const accessToken = await jwt.accessToken(req.user);
-    const { token, cookieOptions } = await jwt.refreshToken(req.user);
-    res.cookie('refreshToken', token, cookieOptions);
     res.status(Status.OK).json(new ResJSON('request success', accessToken));
   } catch (err) {
     next(err);


### PR DESCRIPTION
### 개요
fix:express #151 fix refresh api logic

### 작업 사항
refresh api에서 accessToken 재발급 시 refreshToken은 재발급 되지 않도록 로직 변경

### 변경점

### 목적

### 스크린샷 (optional)
