### PR TITLE
[feat] 레슨 글에 대한 댓글 HTTP API 추가

### DIFF
--- a/munetic_express/src/controllers/comment.controller.ts
+++ b/munetic_express/src/controllers/comment.controller.ts
@@ -45,7 +45,6 @@ export const getCommentsByLessonId: RequestHandler = async (req, res, next) => {
   try {
     let lesson_id: number = parseInt(req.params.lesson_id, 10); 
     if (Number.isNaN(lesson_id)) {
-      console.log("레슨 ID엔 숫자만 올 수 있습니다.");
       next(new ErrorResponse(Status.BAD_REQUEST, '레슨 ID엔 숫자만 올 수 있습니다.'));
     } else if (!req.user) {
       next(new ErrorResponse(Status.UNAUTHORIZED, '로그인이 필요합니다.'));

--- a/munetic_express/src/controllers/comment.controller.ts
+++ b/munetic_express/src/controllers/comment.controller.ts
@@ -1,0 +1,161 @@
+import { RequestHandler } from 'express';
+import Status from 'http-status';
+import ErrorResponse from '../modules/errorResponse';
+import { ResJSON } from '../modules/types';
+import * as CommentService from '../service/comment.service';
+
+/**
+ * 유저에 대한 모든 댓글을 읽어오는 미들웨어
+ * GET Request -> 200, 401 Response
+ * 
+ * @param req request Objrct
+ * @param res response Objrct
+ * @param next next middleware function Object
+ * @author joohongpark
+ */
+export const getCommentsByUserId: RequestHandler = async (req, res, next) => {
+  try {
+    if (!req.user) {
+      next(new ErrorResponse(Status.UNAUTHORIZED, '로그인이 필요합니다.'));
+    } else {
+      let comments = await CommentService.searchAllCommentsByUserId(
+        req.params.user_id
+      );
+      let result: ResJSON = new ResJSON(
+        '유저에 대한 댓글들을 불러오는데 성공하였습니다.',
+        comments,
+      );
+      res.status(Status.OK).json(result);
+    }
+  } catch (err) {
+    next(err);
+  }
+};
+
+/**
+ * 레슨에 대한 모든 댓글을 읽어오는 미들웨어
+ * GET Request -> 200, 400, 401 Response
+ * 
+ * @param req request Objrct
+ * @param res response Objrct
+ * @param next next middleware function Object
+ * @author joohongpark
+ */
+export const getCommentsByLessonId: RequestHandler = async (req, res, next) => {
+  try {
+    let lesson_id: number = parseInt(req.params.lesson_id, 10); 
+    if (Number.isNaN(lesson_id)) {
+      console.log("레슨 ID엔 숫자만 올 수 있습니다.");
+      next(new ErrorResponse(Status.BAD_REQUEST, '레슨 ID엔 숫자만 올 수 있습니다.'));
+    } else if (!req.user) {
+      next(new ErrorResponse(Status.UNAUTHORIZED, '로그인이 필요합니다.'));
+    } else {
+      let comments = await CommentService.searchAllCommentsByLessonId(
+        lesson_id,
+      );
+      let result: ResJSON = new ResJSON(
+        '레슨에 대한 댓글들을 불러오는데 성공하였습니다.',
+        comments,
+      );
+      res.status(Status.OK).json(result);
+    }
+  } catch (err) {
+    next(err);
+  }
+};
+
+/**
+ * 레슨에 댓글을 추가하는 미들웨어
+ * GET Request -> 200, 400, 401 Response
+ * 
+ * @param req request Objrct
+ * @param res response Objrct
+ * @param next next middleware function Object
+ * @author joohongpark
+ */
+export const putComment: RequestHandler = async (req, res, next) => {
+  try {
+    if (!req.body.comment) {
+      next(new ErrorResponse(Status.BAD_REQUEST, '댓글 내용을 적어주세요'));
+    } else if (!req.user) {
+      next(new ErrorResponse(Status.UNAUTHORIZED, '로그인이 필요합니다.'));
+    } else {
+      let comment = await CommentService.addComment(
+        req.user.id,
+        parseInt(req.params.lesson_id, 10),
+        req.body.comment,
+      );
+      let result: ResJSON = new ResJSON(
+        '레슨에 댓글을 저장하는데 성공하였습니다.',
+        comment,
+      );
+      res.status(Status.OK).json(result);
+    }
+  } catch (err) {
+    next(err);
+  }
+};
+
+/**
+ * 댓글 내용을 수정하는 미들웨어
+ * 
+ * @param req request Objrct
+ * @param res response Objrct
+ * @param next next middleware function Object
+ * @author joohongpark
+ */
+export const updateComment: RequestHandler = async (req, res, next) => {
+  try {
+    let comment_id: number = parseInt(req.params.comment_id, 10);
+    if (Number.isNaN(comment_id)) {
+      next(new ErrorResponse(Status.BAD_REQUEST, '댓글 ID엔 숫자만 올 수 있습니다.'));
+    } else if (!req.body.comment) {
+      next(new ErrorResponse(Status.BAD_REQUEST, '댓글 내용을 적어주세요'));
+    } else if (!req.user) {
+      next(new ErrorResponse(Status.UNAUTHORIZED, '로그인이 필요합니다.'));
+    } else {
+      let updated = await CommentService.updateComment(
+        comment_id,
+        req.body.comment,
+      );
+      let result: ResJSON = new ResJSON(
+        updated ? '레슨에 댓글을 업데이트하는데 성공하였습니다.' : '존재하지 않는 댓글입니다.',
+        updated,
+      );
+      res.status(Status.OK).json(result);
+    }
+  } catch (err) {
+    next(err);
+  }
+};
+
+/**
+ * 본인의 댓글을 삭제하는 미들웨어
+ * 
+ * @param req request Objrct
+ * @param res response Objrct
+ * @param next next middleware function Object
+ * @author joohongpark
+ */
+export const delComment: RequestHandler = async (req, res, next) => {
+  try {
+    let comment_id: number = parseInt(req.params.comment_id, 10);
+    if (Number.isNaN(comment_id)) {
+      next(new ErrorResponse(Status.BAD_REQUEST, '댓글 ID엔 숫자만 올 수 있습니다.'));
+    } else if (!req.user) {
+      next(new ErrorResponse(Status.UNAUTHORIZED, '로그인이 필요합니다.'));
+    } else {
+      const del: boolean = await CommentService.removeComment(
+        req.user.id,
+        comment_id,
+      );
+      let result: ResJSON = new ResJSON(
+        del ? '댓글을 삭제하는데 성공하였습니다.' : '이미 삭제되었거나 권한이 없습니다.',
+        del,
+      );
+      res.status(Status.OK).json(result);
+    }
+  } catch (err) {
+    next(err);
+  }
+};

--- a/munetic_express/src/models/comment.ts
+++ b/munetic_express/src/models/comment.ts
@@ -1,0 +1,81 @@
+import { Sequelize, DataTypes, Model, Optional, HasOneGetAssociationMixin } from 'sequelize';
+
+/**
+ * Comment 테이블의 어트리뷰트들을 명시합니다.
+ * 
+ * @Author joohongpark
+ */
+export interface commentAttributes {
+  id: number;
+  user_id: number;
+  lesson_id: number;
+  content: string;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date;
+}
+
+/**
+ * Comment 테이블에 값을 삽입할 때 (자동 생성되어서) 생략해도 되는 데이터를 명시합니다.
+ * 
+ * @Author joohongpark
+ */
+type commentCreationAttributes = Optional<commentAttributes,
+  'id' | 'createdAt' | 'updatedAt' | 'deletedAt'
+>;
+
+/**
+ * Comment 데이터 모델(및 테이블)을 정의합니다.
+ * 
+ * @Author joohongpark
+ */
+export class Comment
+  extends Model<commentAttributes, commentCreationAttributes>
+  implements commentAttributes
+{
+  public id!: number;
+  public user_id!: number;
+  public lesson_id!: number;
+  public content!: string;
+  public readonly createdAt!: Date;
+  public readonly updatedAt!: Date;
+  public readonly deletedAt!: Date;
+
+  static initModel(sequelize: Sequelize): typeof Comment {
+    return Comment.init(
+      {
+        id: {
+          allowNull: false,
+          autoIncrement: true,
+          type: DataTypes.INTEGER,
+          primaryKey: true,
+        },
+        user_id: {
+          allowNull: false,
+          type: DataTypes.INTEGER,
+        },
+        lesson_id: {
+          allowNull: false,
+          type: DataTypes.INTEGER,
+        },
+        content: {
+          allowNull: false,
+          type: DataTypes.STRING(8192),
+        },
+        createdAt: {
+          field: 'createdAt',
+          type: DataTypes.DATE,
+        },
+        updatedAt: {
+          field: 'updatedAt',
+          type: DataTypes.DATE,
+        },
+        deletedAt: {
+          field: 'deletedAt',
+          type: DataTypes.DATE,
+        },
+      },
+      { tableName: 'Comment', sequelize },
+    );
+  }
+}

--- a/munetic_express/src/models/index.ts
+++ b/munetic_express/src/models/index.ts
@@ -2,6 +2,7 @@ import { Sequelize } from 'sequelize';
 import { Category } from './category';
 import { Lesson } from './lesson';
 import { Bookmark } from './bookmark';
+import { Comment } from './comment';
 import { User, Gender, Account } from './user';
 import * as UserService from '../service/user.service';
 
@@ -37,6 +38,7 @@ export function Models() {
   User.initModel(sequelize);
   Lesson.initModel(sequelize);
   Bookmark.initModel(sequelize);
+  Comment.initModel(sequelize);
 
   Category.hasMany(Lesson, {
     foreignKey: {
@@ -72,6 +74,18 @@ export function Models() {
     foreignKey: 'lesson_id',
   });
   Bookmark.belongsTo(Lesson, {
+    foreignKey: 'lesson_id',
+  });
+  User.hasMany(Comment, {
+    foreignKey: 'user_id',
+  });
+  Comment.belongsTo(User, {
+    foreignKey: 'user_id',
+  });
+  Lesson.hasMany(Comment, {
+    foreignKey: 'lesson_id',
+  });
+  Comment.belongsTo(Lesson, {
     foreignKey: 'lesson_id',
   });
   return sequelize;

--- a/munetic_express/src/models/user.ts
+++ b/munetic_express/src/models/user.ts
@@ -1,4 +1,5 @@
-import { Model, Optional, Sequelize, DataTypes } from 'sequelize';
+import { Model, Optional, Sequelize, DataTypes, HasManyGetAssociationsMixin } from 'sequelize';
+import { Comment } from '../models/comment';
 
 export enum Account {
   Student = 'Student',
@@ -74,6 +75,8 @@ export class User
   public readonly createdAt!: Date;
   public readonly updatedAt!: Date;
   public readonly deletedAt!: Date;
+
+  declare getComments: HasManyGetAssociationsMixin<Comment>;
 
   static initModel(sequelize: Sequelize): typeof User {
     return User.init(

--- a/munetic_express/src/routes/comment.routes.ts
+++ b/munetic_express/src/routes/comment.routes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import * as CommentAPI from '../controllers/comment.controller';
+import { jwtAuth } from '../modules/jwt.local.strategy';
+
+export const path = '/comment';
+export const router = Router();
+
+router.get('/user/:user_id', jwtAuth(), CommentAPI.getCommentsByUserId);
+router.get('/lesson/:lesson_id', jwtAuth(), CommentAPI.getCommentsByLessonId);
+router.post('/lesson/:lesson_id', jwtAuth(), CommentAPI.putComment);
+router.put('/:comment_id', jwtAuth(), CommentAPI.updateComment);
+router.delete('/:comment_id', jwtAuth(), CommentAPI.delComment);

--- a/munetic_express/src/routes/index.ts
+++ b/munetic_express/src/routes/index.ts
@@ -7,6 +7,7 @@ import * as lesson from './lesson.routes';
 import * as category from './category.routes';
 import * as admin from './admin/admin.routes';
 import * as bookmark from './bookmark.routes';
+import * as comment from './comment.routes';
 
 import passport from 'passport';
 import AdminStrategy from '../modules/admin.strategy';
@@ -35,3 +36,4 @@ router.use(lesson.path, lesson.router);
 router.use(admin.path, admin.router);
 router.use(category.path, category.router);
 router.use(bookmark.path, bookmark.router);
+router.use(comment.path, comment.router);

--- a/munetic_express/src/service/comment.service.ts
+++ b/munetic_express/src/service/comment.service.ts
@@ -1,0 +1,122 @@
+import { Op } from 'sequelize';
+import Status from 'http-status';
+import ErrorResponse from '../modules/errorResponse';
+import { Comment } from '../models/comment';
+import { Lesson } from '../models/lesson';
+import { User } from '../models/user';
+
+/**
+ * user 로그인 id의 모든 댓글 조회
+ * 
+ * @param user_id user login ID
+ * @returns Promise<Comment[]>
+ * @throws ErrorResponse if the user login ID is not exists.
+ * @author joohongpark
+ */
+export const searchAllCommentsByUserId = async (
+  user_id: string,
+): Promise< Comment[] > => {
+  const searchUserID = await User.findOne({
+    where: {
+      login_id: user_id,
+    }
+  });
+  if (!searchUserID)
+    throw new ErrorResponse(Status.BAD_REQUEST, '유효하지 않은 유저 id입니다.');
+  const searchAllComments = await searchUserID.getComments();
+  return searchAllComments;
+};
+
+/**
+ * 레슨 id에 대한 모든 댓글 조회
+ * 
+ * @param lesson_id lesson ID
+ * @returns Promise<Bookmark>
+ * @author joohongpark
+ */
+export const searchAllCommentsByLessonId = async (
+  lesson_id: number,
+): Promise< Comment[] > => {
+  const searchAllComments = await Comment.findAll({
+    where: {
+      lesson_id,
+    }
+  })
+  return searchAllComments;
+};
+
+/**
+ * 레슨에 댓글 추가
+ * 
+ * @param user_id user ID
+ * @param lesson_id lesson ID
+ * @param comment comment
+ * @returns Promise<Comment>
+ * @throws ErrorResponse if it fails to register to comment.
+ * @author joohongpark
+ */
+export const addComment = async (
+  user_id: number,
+  lesson_id: number,
+  comment: string,
+): Promise< Comment > => {
+  const newComment: Comment = Comment.build({
+    user_id,
+    lesson_id,
+    content: comment,
+  });
+  const rtn = newComment.save().catch(() => {
+    throw new ErrorResponse(Status.BAD_REQUEST, '댓글 등록에 실패하였습니다.');
+  });
+  return rtn;
+};
+
+/**
+ * 댓글 수정
+ * 
+ * @param comment_id comment ID
+ * @param comment comment
+ * @returns Promise< boolean >
+ * @author joohongpark
+ */
+export const updateComment = async (
+  comment_id: number,
+  comment: string,
+): Promise< boolean > => {
+  const rtn = await Comment.update(
+    {
+      content: comment,
+    },
+    {
+      where: {
+        id: comment_id,
+      }
+    }
+  );
+  return rtn[0] > 0;
+};
+
+/**
+ * user의 댓글을 삭제
+ * 
+ * @param user_id user ID
+ * @param comment_id comment ID
+ * @returns Promise<boolean>
+ * @author joohongpark
+ */
+export const removeComment = async (
+  user_id: number,
+  comment_id: number,
+): Promise< boolean > => {
+  const checkExistence = await Comment.findOne({
+    where: {
+      [Op.and]: [
+        { user_id },
+        { id: comment_id },
+      ]
+    }
+  });
+  if (!checkExistence) return false;
+  await checkExistence.destroy();
+  return true;
+};

--- a/munetic_express/src/service/comment.service.ts
+++ b/munetic_express/src/service/comment.service.ts
@@ -23,7 +23,17 @@ export const searchAllCommentsByUserId = async (
   });
   if (!searchUserID)
     throw new ErrorResponse(Status.BAD_REQUEST, '유효하지 않은 유저 id입니다.');
-  const searchAllComments = await searchUserID.getComments();
+  const searchAllComments = await searchUserID.getComments({
+    attributes: {
+      exclude: ['user_id', 'createdAt', 'deletedAt'],
+    },
+    include: [
+      {
+        model: Lesson,
+        attributes: ["id", "category_id", "title"],
+      }
+    ],
+  });
   return searchAllComments;
 };
 
@@ -40,7 +50,16 @@ export const searchAllCommentsByLessonId = async (
   const searchAllComments = await Comment.findAll({
     where: {
       lesson_id,
-    }
+    },
+    attributes: {
+      exclude: ['user_id', 'createdAt', 'deletedAt'],
+    },
+    include: [
+      {
+        model: User,
+        attributes: ["type", "login_id", "nickname", "image_url"],
+      }
+    ],
   })
   return searchAllComments;
 };

--- a/munetic_express/src/swagger/apis/comment.yml
+++ b/munetic_express/src/swagger/apis/comment.yml
@@ -1,0 +1,227 @@
+swagger: '2.0'
+info:
+  title: API Title
+  version: '1.0'
+tags:
+  - name: Comment
+    description: '레슨 글에 대한 댓글 조회, 추가, 변경, 삭제'
+paths:
+  /comment/user/{user_id}:
+    get:
+      tags:
+        - Comment
+      summary: '유저 로그인 id에 대한 모든 댓글 조회'
+      parameters:
+        - name: Authorization
+          in: header
+          type: string
+        - name: 'user_id'
+          in: path
+          description: 'user login ID'
+          type: string
+          required: true
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: '유저에 대한 모든 댓글'
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: '유저에 대한 댓글들을 불러오는데 성공하였습니다.'
+              data:
+                type: array
+                items:
+                  $ref: '#definitions/CommentByUser'
+        '401':
+          description: 'Invalid JWT token'
+          schema:
+            type: string
+            example: Unauthorized
+  /comment/lesson/{lesson_id}:
+    get:
+      tags:
+        - Comment
+      summary: '레슨 ID에 대한 모든 댓글 조회'
+      produces:
+        - application/json
+      parameters:
+        - name: Authorization
+          in: header
+          type: string
+        - name: 'lesson_id'
+          in: path
+          description: 'lesson ID'
+          type: integer
+          format: int32
+          required: true
+      responses:
+        '200':
+          description: '레슨에 대한 모든 댓글'
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: 레슨에 대한 댓글들을 불러오는데 성공하였습니다.'
+              data:
+                type: array
+                items:
+                  $ref: '#definitions/CommentByLesson'
+        '400':
+          description: 레슨 ID 형식이 숫자가 아닐 때
+          schema:
+            type: string
+            example: '레슨 ID엔 숫자만 올 수 있습니다.'
+        '401':
+          description: 'Invalid JWT token'
+          schema:
+            type: string
+            example: Unauthorized
+    post:
+      tags:
+        - Comment
+      summary: '레슨 ID에 대한 댓글 추가'
+      produces:
+        - application/json
+      parameters:
+        - name: Authorization
+          in: header
+          type: string
+        - name: 'lesson_id'
+          in: path
+          description: 'lesson id'
+          type: integer
+          format: int32
+          required: true
+        - name: comment
+          in: body
+          description: 'new Comment'
+          schema:
+            type: object
+            required:
+              - 'comment'
+            properties:
+              comment:
+                type: string
+      responses:
+        '200':
+          description: 댓글 추가에 성공하였을 때
+          schema:
+            required:
+              - message
+              - data
+            properties:
+              message:
+                type: string
+                example: '레슨에 댓글을 추가하는데 성공하였습니다.'
+              data:
+                type: object
+                $ref: '#definitions/Comment'
+        '400':
+          description: '빈 댓글을 전송할 때'
+          schema:
+            type: string
+            example: '댓글 내용을 적어주세요'
+        '401':
+          description: 'Invalid JWT token'
+          schema:
+            type: string
+            example: Unauthorized
+  /comment/{comment_id}:
+    put:
+      tags:
+        - Comment
+      summary: '댓글 수정'
+      produces:
+        - application/json
+      parameters:
+        - name: Authorization
+          in: header
+          type: string
+        - name: 'comment_id'
+          in: path
+          description: 'Comment ID'
+          type: integer
+          format: int32
+          required: true
+        - name: comment
+          in: body
+          description: 'new Comment'
+          schema:
+            type: object
+            required:
+              - 'comment'
+            properties:
+              comment:
+                type: string
+      responses:
+        '200':
+          description: 댓글 업데이트에 성공하거나 존재하지 않는 댓글일 때
+          schema:
+            required:
+              - message
+              - data
+            properties:
+              message:
+                description: '댓글 업데이트 여부에 대한 메시지'
+                type: string
+                example: '레슨에 댓글을 업데이트하는데 성공하였습니다.'
+              data:
+                description: '댓글 업데이트 여부'
+                type: boolean
+                example: true
+        '400':
+          description: 레슨 ID 형식이 숫자가 아닐 때
+          schema:
+            type: string
+            example: '레슨 ID엔 숫자만 올 수 있습니다.'
+        '401':
+          description: 'Invalid JWT token'
+          schema:
+            type: string
+            example: Unauthorized
+    delete:
+      tags:
+        - Comment
+      summary: '댓글 삭제'
+      produces:
+        - application/json
+      parameters:
+        - name: Authorization
+          in: header
+          type: string
+        - name: 'comment_id'
+          in: path
+          description: 'Comment ID'
+          type: integer
+          format: int32
+          required: true
+      responses:
+        '200':
+          description: 댓글 삭제에 성공하거나 권한이 없을 때
+          schema:
+            required:
+              - message
+              - data
+            properties:
+              message:
+                description: '댓글을 삭제하는데 성공하였습니다.'
+                type: string
+                example: '댓글을 삭제하는데 성공하였습니다.'
+              data:
+                description: '댓글 삭제 여부'
+                type: boolean
+                example: true
+        '400':
+          description: 댓글 ID 형식이 숫자가 아닐 때
+          schema:
+            type: string
+            example: '댓글 ID엔 숫자만 올 수 있습니다.'
+        '401':
+          description: 'Invalid JWT token'
+          schema:
+            type: string
+            example: Unauthorized

--- a/munetic_express/src/swagger/definitions.yml
+++ b/munetic_express/src/swagger/definitions.yml
@@ -269,3 +269,74 @@ definitions:
         # TODO: 레슨 타입에 대한 명확한 정의 필요 joopark
         description: 'Lesson Object'
         type: object
+
+  Comment:
+    type: object
+    properties:
+      id:
+        description: 'Comment ID'
+        type: number
+        format: int32
+      user_id:
+        description: 'User ID'
+        type: number
+        format: int32
+      lesson_id:
+        description: 'Lesson ID'
+        type: number
+        format: int32
+      content:
+        description: 'comment'
+        type: string
+      updatedAt:
+        description: 'The time when the Column was updated'
+        type: string
+      createdAt:
+        description: 'The time when the Column was created'
+        type: string
+
+  CommentByUser:
+    type: object
+    properties:
+      id:
+        description: 'Comment ID'
+        type: number
+        format: int32
+      lesson_id:
+        description: 'Lesson ID'
+        type: number
+        format: int32
+      content:
+        description: 'comment'
+        type: string
+      updatedAt:
+        description: 'The time when the Column was updated'
+        type: string
+      Lesson:
+        description: 'lesson of comment'
+        type: object
+
+  CommentByLesson:
+    type: object
+    required:
+      - 'id'
+      - 'content'
+      - 'updatedAt'
+    properties:
+      id:
+        description: 'Comment ID'
+        type: number
+        format: int32
+      lesson_id:
+        description: 'Lesson ID'
+        type: number
+        format: int32
+      content:
+        description: '댓글 내용'
+        type: string
+      updatedAt:
+        description: 'The time when the Column was updated'
+        type: string
+      User:
+        description: 'user who wrote comment'
+        type: object


### PR DESCRIPTION
### 개요
레슨 글에 대한 댓글 HTTP API 추가

### 작업 사항
- 레슨 글에 대한 댓글 컨트롤러, DB 모델, 라우트, 서비스, Swagger 명세 추가

### 변경점
- 레슨 글에 대한 댓글 컨트롤러, DB 모델, 라우트, 서비스, Swagger 명세 추가

### 목적
레슨 글에 대한 댓글을 구현하기 위함

### 스크린샷 (optional)
