### PR TITLE
[feat] 리플 기능 구현 - 댓글 표시(레슨 게시글 내)

### DIFF
--- a/munetic_app/src/components/lesson/Class.tsx
+++ b/munetic_app/src/components/lesson/Class.tsx
@@ -110,16 +110,16 @@ const ClassContent = styled.div`
  */
 function convertComment(arr: ReadonlyArray<any>): ReadonlyArray<CommentDataType> {
   // FIXME: 추후에 브라우저 로컬저장소 ID에 double quote 들어가는거 제거해야 함.
-  // FIXME: 다음 커밋에 백엔드단에 별, 댓글 생성 날짜 가져오는거 추가해야 함.
   const login_id: string | undefined = localStorage.getItem('user')?.replace(/["]+/g, '');
   return (arr.map((comment: any) => 
     ({
       commentListId: comment.id,
       nickname: comment.User.nickname,
       text: comment.content,
-      date: "02.07",
-      stars: 2,
+      date: (comment.updatedAt !== null) ? comment.updatedAt : comment.createdAt,
+      stars: comment.stars,
       accessible: (comment.User.login_id === login_id),
+      modified: (comment.updatedAt !== null),
     })
   ));
 };

--- a/munetic_app/src/components/lesson/Class.tsx
+++ b/munetic_app/src/components/lesson/Class.tsx
@@ -12,6 +12,7 @@ import { LessonData } from '../../types/lessonData';
 import { CommentDataType } from '../../types/commentData';
 import { Gender } from '../../types/enums';
 import Comment from './Comment';
+import CommentTop from './CommentTop';
 
 const ClassContainer = styled.div`
   margin: 10px;
@@ -195,6 +196,31 @@ export default function Class() {
     '수업 시간': minute_per_lesson,
   };
 
+  const getComment = async () => {
+    try {
+      const lesson_id: number = Number(classId);
+      const res = await CommentAPI.getCommentByLesson(lesson_id);
+      const comments_arr = convertComment(res.data.data);
+      setComments(comments_arr);
+    } catch (e) {
+      console.log(e, 'id로 레슨을 불러오지 못했습니다.');
+    }
+  }
+
+  const sortByStar = () => {
+    const new_comments = [...comments].sort((a: CommentDataType, b: CommentDataType) => (
+      b.stars - a.stars
+    ));
+    setComments(new_comments);
+  }
+
+  const sortByTime = () => {
+    const new_comments = [...comments].sort((a: CommentDataType, b: CommentDataType) => (
+      a.commentListId - b.commentListId
+    ));
+    setComments(new_comments);
+  }
+
   useEffect(() => {
     async function getLessonById(id: string) {
       try {
@@ -204,18 +230,9 @@ export default function Class() {
         console.log(e, 'id로 레슨을 불러오지 못했습니다.');
       }
     }
-    async function getComment(lesson_id: number) {
-      try {
-        const res = await CommentAPI.getCommentByLesson(lesson_id);
-        const comments_arr = convertComment(res.data.data);
-        setComments(comments_arr);
-      } catch (e) {
-        console.log(e, 'id로 레슨을 불러오지 못했습니다.');
-      }
-    }
     if (classId) {
       getLessonById(classId);
-      getComment(Number(classId));
+      getComment();
     }
   }, [classId]);
 
@@ -252,6 +269,7 @@ export default function Class() {
           <div className="contentText">{content}</div>
         </div>
       </ClassContent>
+      <CommentTop commentCount={comments.length} refrash={getComment} sortByTime={sortByTime} sortByStar={sortByStar} />
       <Comment comments_arr={comments} />
     </ClassContainer>
   );

--- a/munetic_app/src/components/lesson/Class.tsx
+++ b/munetic_app/src/components/lesson/Class.tsx
@@ -214,6 +214,13 @@ export default function Class() {
     setComments(new_comments);
   }
 
+  const decSortByStar = () => {
+    const new_comments = [...comments].sort((a: CommentDataType, b: CommentDataType) => (
+      a.stars - b.stars
+    ));
+    setComments(new_comments);
+  }
+
   const sortByTime = () => {
     const new_comments = [...comments].sort((a: CommentDataType, b: CommentDataType) => (
       a.commentListId - b.commentListId
@@ -269,7 +276,12 @@ export default function Class() {
           <div className="contentText">{content}</div>
         </div>
       </ClassContent>
-      <CommentTop commentCount={comments.length} refrash={getComment} sortByTime={sortByTime} sortByStar={sortByStar} />
+      <CommentTop
+        commentCount={comments.length}
+        refrash={getComment}
+        sortByTime={sortByTime}
+        incSortByStar={sortByStar}
+        decSortByStar={decSortByStar} />
       <Comment comments_arr={comments} />
     </ClassContainer>
   );

--- a/munetic_app/src/components/lesson/Class.tsx
+++ b/munetic_app/src/components/lesson/Class.tsx
@@ -9,6 +9,7 @@ import palette from '../../style/palette';
 import * as LessonAPI from '../../lib/api/lesson';
 import { LessonData } from '../../types/lessonData';
 import { Gender } from '../../types/enums';
+import Comment from './Comment';
 
 const ClassContainer = styled.div`
   margin: 10px;
@@ -96,6 +97,42 @@ const ClassContent = styled.div`
     font-size: 16px;
   }
 `;
+
+/**
+ * 목업용 데이터 (서버 연동 후 삭제 예정)
+ * 
+ * @author joohongpark
+ */
+const comments_arr_ex = [
+  {
+    commentListId: 1,
+    nickname: "주팍",
+    text: "와 이강의 대박인데요? 짱이다",
+    date: "02.07",
+    stars: 1
+  },
+  {
+    commentListId: 2,
+    nickname: "joopark",
+    text: "ㄴ 그러니깐요 진짜 백점짜리 강의인거같아요",
+    date: "02.07",
+    stars: 2
+  },
+  {
+    commentListId: 3,
+    nickname: "푸주",
+    text: "ㄴ ㄹㅇㅋㅋ",
+    date: "02.07",
+    stars: 3
+  },
+  {
+    commentListId: 4,
+    nickname: "마라탕",
+    text: "ㄴㄴ ㄹㅇㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ",
+    date: "02.07",
+    stars: 5
+  },
+];
 
 interface InfosType {
   나이: string;
@@ -213,6 +250,7 @@ export default function Class() {
           <div className="contentText">{content}</div>
         </div>
       </ClassContent>
+      <Comment comments_arr={comments_arr_ex} />
     </ClassContainer>
   );
 }

--- a/munetic_app/src/components/lesson/Comment.tsx
+++ b/munetic_app/src/components/lesson/Comment.tsx
@@ -1,0 +1,160 @@
+import styled from 'styled-components';
+import palette from '../../style/palette';
+
+/**
+ * 프로퍼티로 전달되는 댓글 배열의 원소 타입을 지정합니다.
+ * 
+ * @author joohongpark
+ */
+interface CommentDataType {
+  commentListId: number;
+  nickname: string;
+  text: string;
+  date: string;
+  stars: number;
+}
+
+/**
+ * 프로퍼티로 받아야 하는 댓글 배열의 타입을 지정합니다.
+ * 
+ * @author joohongpark
+ */
+interface CommentPropsType {
+  comments_arr: ReadonlyArray<CommentDataType>;
+}
+
+/**
+ * 댓글이 없을 경우 렌더링되는 컴포넌트입니다.
+ * styled-components를 이용해 리액트 컴포넌트로 만들어 스타일을 적용합니다.
+ * 
+ * @author joohongpark
+ */
+const EmptyComments = styled.div`
+  margin: 10px 0;
+  padding: 25px 15px;
+  color: ${palette.darkBlue};
+`;
+
+/**
+ * 댓글의 최상위 요소 (ul 태그) 컴포넌트입니다.
+ * styled-components를 이용해 리액트 컴포넌트로 만들어 스타일을 적용합니다.
+ * 
+ * @author joohongpark
+ */
+const UnorderListComments = styled.ul`
+  padding: 15px 3px;
+  font-size: 17px;
+  font-weight: bold;
+  color: ${palette.darkBlue};
+  border-bottom: 1px solid ${palette.darkBlue};
+  margin-bottom: 60px !important; /* FIXME: 하단바에 댓글이 가려저 임시로 넣었는데 근본적인 해결이 필요할 듯 합니다. */
+`;
+
+/**
+ * 댓글 하나의 요소 (li 태그) 컴포넌트입니다.
+ * styled-components를 이용해 리액트 컴포넌트로 만들어 스타일을 적용합니다.
+ * 
+ * @author joohongpark
+ */
+const ListComment = styled.li`
+  border-top: 1px solid ${palette.lightBlue};
+  padding: 5px 12px;
+  position: relative;
+  /*background-color: ${palette.ivory};*/
+`;
+
+/**
+ * 댓글의 닉네임 (span 태그) 컴포넌트입니다.
+ * styled-components를 이용해 리액트 컴포넌트로 만들어 스타일을 적용합니다.
+ * 
+ * @author joohongpark
+ */
+const Nickname = styled.span`
+  font-size: 14px;
+  line-height: 1.5;
+  color: #000;
+  display: inline-block;
+`;
+
+/**
+ * 댓글의 내용 (p 태그) 컴포넌트입니다.
+ * styled-components를 이용해 리액트 컴포넌트로 만들어 스타일을 적용합니다.
+ * 
+ * @author joohongpark
+ */
+const Text = styled.p`
+  font-size: 16px;
+  line-height: 1.5;
+  color: #000;
+  word-break: break-all;
+  word-wrap: break-word;
+  margin-top: 2px;
+`;
+
+/**
+ * 댓글의 날짜 (span 태그) 컴포넌트입니다.
+ * styled-components를 이용해 리액트 컴포넌트로 만들어 스타일을 적용합니다.
+ * 
+ * @author joohongpark
+ */
+const Date = styled.span`
+  display: block;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #999;
+`;
+
+/**
+ * 댓글의 수정 및 삭제 버튼을 감싸는 (div 태그) 컴포넌트입니다.
+ * styled-components를 이용해 리액트 컴포넌트로 만들어 스타일을 적용합니다.
+ * 
+ * @author joohongpark
+ */
+const Buttons = styled.div`
+  position: absolute;
+  top: 3px;
+  right: 8px;
+`;
+
+/**
+ * 댓글의 별 개수를 감싸는 (div 태그) 컴포넌트입니다.
+ * styled-components를 이용해 리액트 컴포넌트로 만들어 스타일을 적용합니다.
+ * 
+ * @author joohongpark
+ */
+const Stars = styled.div`
+  position: absolute;
+  bottom: 3px;
+  right: 8px;
+  font-size: 12px;
+`;
+
+/**
+ * 댓글 컴포넌트입니다. 프로퍼티로 댓글의 배열을 넣어야 합니다. 댓글이 없을 경우 빈 배열을 넣어야 합니다.
+ * 
+ * @param props.comments_arr 댓글 배열
+ * @returns 리액트 앨리먼트
+ */
+export default function Comment({comments_arr} : CommentPropsType) {
+  const comments = comments_arr.map((comment: CommentDataType) =>
+    <ListComment key={comment.commentListId}>
+      <Nickname>{comment.nickname}</Nickname>
+      <Text>{comment.text}</Text>
+      <Date>{comment.date}</Date>
+      <Buttons>
+        <button className="del">수정</button>
+        <button className="mod">삭제</button>
+      </Buttons>
+      <Stars>
+      {'⭑'.repeat(comment.stars)}
+      </Stars>
+    </ListComment>
+  )
+  return (comments.length ? 
+    (
+      <UnorderListComments>{comments}</UnorderListComments>
+    ) : (
+      <EmptyComments>등록된 댓글이 없습니다.</EmptyComments>
+    )
+  );
+}

--- a/munetic_app/src/components/lesson/Comment.tsx
+++ b/munetic_app/src/components/lesson/Comment.tsx
@@ -1,27 +1,6 @@
 import styled from 'styled-components';
 import palette from '../../style/palette';
-
-/**
- * 프로퍼티로 전달되는 댓글 배열의 원소 타입을 지정합니다.
- * 
- * @author joohongpark
- */
-interface CommentDataType {
-  commentListId: number;
-  nickname: string;
-  text: string;
-  date: string;
-  stars: number;
-}
-
-/**
- * 프로퍼티로 받아야 하는 댓글 배열의 타입을 지정합니다.
- * 
- * @author joohongpark
- */
-interface CommentPropsType {
-  comments_arr: ReadonlyArray<CommentDataType>;
-}
+import { CommentDataType, CommentPropsType } from '../../types/commentData';
 
 /**
  * 댓글이 없을 경우 렌더링되는 컴포넌트입니다.
@@ -141,10 +120,13 @@ export default function Comment({comments_arr} : CommentPropsType) {
       <Nickname>{comment.nickname}</Nickname>
       <Text>{comment.text}</Text>
       <Date>{comment.date}</Date>
-      <Buttons>
-        <button className="del">수정</button>
-        <button className="mod">삭제</button>
-      </Buttons>
+      {
+        comment.accessible && 
+          <Buttons>
+            <button className="del">수정</button>
+            <button className="mod">삭제</button>
+          </Buttons>
+      }
       <Stars>
       {'⭑'.repeat(comment.stars)}
       </Stars>

--- a/munetic_app/src/components/lesson/Comment.tsx
+++ b/munetic_app/src/components/lesson/Comment.tsx
@@ -84,6 +84,19 @@ const Date = styled.span`
 `;
 
 /**
+ * 댓글의 수정 여부를 나타내는 (span 태그) 컴포넌트입니다.
+ * styled-components를 이용해 리액트 컴포넌트로 만들어 스타일을 적용합니다.
+ * 
+ * @author joohongpark
+ */
+const Modified = styled.span`
+  padding: 5px 12px;
+  font-size: 9px;
+  font-style: italic;
+  color: ${palette.darkBlue};
+`;
+
+/**
  * 댓글의 수정 및 삭제 버튼을 감싸는 (div 태그) 컴포넌트입니다.
  * styled-components를 이용해 리액트 컴포넌트로 만들어 스타일을 적용합니다.
  * 
@@ -117,7 +130,10 @@ const Stars = styled.div`
 export default function Comment({comments_arr} : CommentPropsType) {
   const comments = comments_arr.map((comment: CommentDataType) =>
     <ListComment key={comment.commentListId}>
-      <Nickname>{comment.nickname}</Nickname>
+      <Nickname>
+        {comment.nickname}
+        {comment.modified && <Modified>(댓글 수정됨)</Modified>}
+      </Nickname>
       <Text>{comment.text}</Text>
       <Date>{comment.date}</Date>
       {

--- a/munetic_app/src/components/lesson/CommentTop.tsx
+++ b/munetic_app/src/components/lesson/CommentTop.tsx
@@ -75,7 +75,7 @@ const RightBox = styled.div`
  * @returns 리액트 앨리먼트 
  * @author joohongpark
  */
-export default function CommentTop({refrash, sortByTime, sortByStar, commentCount}: FunctionPropsType) {
+export default function CommentTop({refrash, sortByTime, incSortByStar, decSortByStar, commentCount}: FunctionPropsType) {
   return (
   <ContentBox>
     <LeftBox>
@@ -83,9 +83,10 @@ export default function CommentTop({refrash, sortByTime, sortByStar, commentCoun
       <CommentCount>{commentCount}</CommentCount>
     </LeftBox>
     <RightBox>
-      <TextBox><button className="del" onClick={refrash}>새로고침</button></TextBox>
-      <TextBox><button className="del" onClick={sortByTime}>등록순</button></TextBox>
-      <TextBox><button className="del" onClick={sortByStar}>별점순</button></TextBox>
+      <TextBox><button onClick={refrash}>새로고침</button></TextBox>
+      <TextBox><button onClick={sortByTime}>등록순</button></TextBox>
+      <TextBox><button onClick={incSortByStar}>별점 높은순</button></TextBox>
+      <TextBox><button onClick={decSortByStar}>별점 낮은순</button></TextBox>
     </RightBox>
   </ContentBox>
   );

--- a/munetic_app/src/components/lesson/CommentTop.tsx
+++ b/munetic_app/src/components/lesson/CommentTop.tsx
@@ -1,0 +1,92 @@
+import styled from 'styled-components';
+import palette from '../../style/palette';
+import { FunctionPropsType } from '../../types/commentTopData';
+
+/**
+ * 댓글 상단 메뉴를 감싸는 컴포넌트입니다.
+ * styled-components를 이용해 리액트 컴포넌트로 만들어 스타일을 적용합니다.
+ * 
+ * @author joohongpark
+ */
+const ContentBox = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 12px 12px;
+`;
+
+/**
+ * 댓글 상단 메뉴 내의 왼쪽 컴포넌트들을 감싸는 컴포넌트입니다.
+ * styled-components를 이용해 리액트 컴포넌트로 만들어 스타일을 적용합니다.
+ * 
+ * @author joohongpark
+ */
+const LeftBox = styled.div`
+  color: #000;
+  font-size: 15px;
+  line-height: 1.5;
+`;
+
+/**
+ * 텍스트를 감싸는 컴포넌트입니다.
+ * styled-components를 이용해 리액트 컴포넌트로 만들어 스타일을 적용합니다.
+ * 
+ * @author joohongpark
+ */
+const TextBox = styled.span`
+  font-weight: normal;
+  margin-left: 4px;
+  display: inline-block;
+  vertical-align: top;
+`;
+
+/**
+ * 댓글 개수를 나타내는 컴포넌트입니다.
+ * styled-components를 이용해 리액트 컴포넌트로 만들어 스타일을 적용합니다.
+ * 
+ * @author joohongpark
+ */
+const CommentCount = styled.span`
+  font-weight: normal;
+  color: ${palette.red};
+  margin-left: 4px;
+  vertical-align: top;
+  display: inline-block;
+`;
+
+/**
+ * 댓글 상단 메뉴 내의 오른쪽 컴포넌트들을 감싸는 컴포넌트입니다.
+ * styled-components를 이용해 리액트 컴포넌트로 만들어 스타일을 적용합니다.
+ * 
+ * @author joohongpark
+ */
+const RightBox = styled.div`
+  margin-left: auto;
+  font-size: 13px;
+  vertical-align: top;
+`;
+
+/**
+ * 댓글의 상단바 컴포넌트입니다.
+ * 
+ * @param props.refrash 새로고침 함수
+ * @param props.sortByTime 시간순 정렬 함수
+ * @param props.sortByStar 별개수별 정렬 함수
+ * @param props.commentCount 댓글 개수
+ * @returns 리액트 앨리먼트 
+ * @author joohongpark
+ */
+export default function CommentTop({refrash, sortByTime, sortByStar, commentCount}: FunctionPropsType) {
+  return (
+  <ContentBox>
+    <LeftBox>
+      <TextBox>전체 댓글</TextBox>
+      <CommentCount>{commentCount}</CommentCount>
+    </LeftBox>
+    <RightBox>
+      <TextBox><button className="del" onClick={refrash}>새로고침</button></TextBox>
+      <TextBox><button className="del" onClick={sortByTime}>등록순</button></TextBox>
+      <TextBox><button className="del" onClick={sortByStar}>별점순</button></TextBox>
+    </RightBox>
+  </ContentBox>
+  );
+}

--- a/munetic_app/src/lib/api/comment.ts
+++ b/munetic_app/src/lib/api/comment.ts
@@ -1,0 +1,5 @@
+import client from './client';
+
+export const getCommentByLesson = async (lesson_id: number) => {
+  return await client.get(`/comment/lesson/${lesson_id}`)
+}

--- a/munetic_app/src/style/palette.ts
+++ b/munetic_app/src/style/palette.ts
@@ -4,5 +4,5 @@ export default {
   lightBlue: '#a8dadc',
   green: '#f1faee',
   ivory: '#fbfefb',
-  red: '#e63946',
+  red: '#d22227',
 };

--- a/munetic_app/src/types/commentData.d.ts
+++ b/munetic_app/src/types/commentData.d.ts
@@ -1,0 +1,22 @@
+/**
+ * 프로퍼티로 전달되는 댓글 배열의 원소 타입을 지정합니다.
+ * 
+ * @author joohongpark
+ */
+export interface CommentDataType {
+  commentListId: number;
+  nickname: string;
+  text: string;
+  date: string;
+  stars: number;
+  accessible: boolean;
+}
+
+/**
+ * 프로퍼티로 받아야 하는 댓글 배열의 타입을 지정합니다.
+ * 
+ * @author joohongpark
+ */
+export interface CommentPropsType {
+  comments_arr: ReadonlyArray<CommentDataType>;
+}

--- a/munetic_app/src/types/commentData.d.ts
+++ b/munetic_app/src/types/commentData.d.ts
@@ -10,6 +10,7 @@ export interface CommentDataType {
   date: string;
   stars: number;
   accessible: boolean;
+  modified: boolean;
 }
 
 /**

--- a/munetic_app/src/types/commentTopData.d.ts
+++ b/munetic_app/src/types/commentTopData.d.ts
@@ -7,6 +7,7 @@
  export interface FunctionPropsType {
   refrash: () => void;
   sortByTime: () => void;
-  sortByStar: () => void;
+  incSortByStar: () => void;
+  decSortByStar: () => void;
   commentCount: number;
 }

--- a/munetic_app/src/types/commentTopData.d.ts
+++ b/munetic_app/src/types/commentTopData.d.ts
@@ -1,0 +1,12 @@
+/**
+ * CommentTop 컴포넌트가 프로퍼티로 받아야 하는 타입을 지정합니다.
+ * 댓글 새로고침 함수, 시간순 정렬 함수, 별 개수순 정렬 함수, 댓글 개수를 받습니다.
+ * 
+ * @author joohongpark
+ */
+ export interface FunctionPropsType {
+  refrash: () => void;
+  sortByTime: () => void;
+  sortByStar: () => void;
+  commentCount: number;
+}

--- a/munetic_express/src/controllers/comment.controller.ts
+++ b/munetic_express/src/controllers/comment.controller.ts
@@ -74,15 +74,22 @@ export const getCommentsByLessonId: RequestHandler = async (req, res, next) => {
  */
 export const putComment: RequestHandler = async (req, res, next) => {
   try {
-    if (!req.body.comment) {
+    let lesson_id: number = parseInt(req.params.lesson_id, 10);
+    let stars: number = parseInt(req.body.stars, 10);
+    if (Number.isNaN(lesson_id) || Number.isNaN(stars)) {
+      next(new ErrorResponse(Status.BAD_REQUEST, '레슨 ID 혹은 별 개수엔 숫자만 올 수 있습니다.'));
+    } else if (stars < 0 || stars > 5) {
+      next(new ErrorResponse(Status.BAD_REQUEST, '별 개수는 1부터 5까지 입력 가능합니다.'));
+    } else if (!req.body.comment) {
       next(new ErrorResponse(Status.BAD_REQUEST, '댓글 내용을 적어주세요'));
     } else if (!req.user) {
       next(new ErrorResponse(Status.UNAUTHORIZED, '로그인이 필요합니다.'));
     } else {
       let comment = await CommentService.addComment(
         req.user.id,
-        parseInt(req.params.lesson_id, 10),
+        lesson_id,
         req.body.comment,
+        stars,
       );
       let result: ResJSON = new ResJSON(
         '레슨에 댓글을 저장하는데 성공하였습니다.',
@@ -106,8 +113,11 @@ export const putComment: RequestHandler = async (req, res, next) => {
 export const updateComment: RequestHandler = async (req, res, next) => {
   try {
     let comment_id: number = parseInt(req.params.comment_id, 10);
-    if (Number.isNaN(comment_id)) {
-      next(new ErrorResponse(Status.BAD_REQUEST, '댓글 ID엔 숫자만 올 수 있습니다.'));
+    let stars: number = parseInt(req.body.stars, 10);
+    if (Number.isNaN(comment_id) || Number.isNaN(stars)) {
+      next(new ErrorResponse(Status.BAD_REQUEST, '댓글 ID 혹은 별 개수엔 숫자만 올 수 있습니다.'));
+    } else if (stars < 0 || stars > 5) {
+      next(new ErrorResponse(Status.BAD_REQUEST, '별 개수는 1부터 5까지 입력 가능합니다.'));
     } else if (!req.body.comment) {
       next(new ErrorResponse(Status.BAD_REQUEST, '댓글 내용을 적어주세요'));
     } else if (!req.user) {
@@ -116,6 +126,7 @@ export const updateComment: RequestHandler = async (req, res, next) => {
       let updated = await CommentService.updateComment(
         comment_id,
         req.body.comment,
+        stars,
       );
       let result: ResJSON = new ResJSON(
         updated ? '레슨에 댓글을 업데이트하는데 성공하였습니다.' : '존재하지 않는 댓글입니다.',

--- a/munetic_express/src/models/comment.ts
+++ b/munetic_express/src/models/comment.ts
@@ -10,6 +10,7 @@ export interface commentAttributes {
   user_id: number;
   lesson_id: number;
   content: string;
+  stars: number;
   createdAt: Date;
   updatedAt: Date;
   deletedAt: Date;
@@ -37,6 +38,7 @@ export class Comment
   public user_id!: number;
   public lesson_id!: number;
   public content!: string;
+  public stars!: number;
   public readonly createdAt!: Date;
   public readonly updatedAt!: Date;
   public readonly deletedAt!: Date;
@@ -61,6 +63,10 @@ export class Comment
         content: {
           allowNull: false,
           type: DataTypes.STRING(8192),
+        },
+        stars: {
+          allowNull: false,
+          type: DataTypes.INTEGER,
         },
         createdAt: {
           field: 'createdAt',

--- a/munetic_express/src/service/comment.service.ts
+++ b/munetic_express/src/service/comment.service.ts
@@ -52,7 +52,7 @@ export const searchAllCommentsByLessonId = async (
       lesson_id,
     },
     attributes: {
-      exclude: ['user_id', 'createdAt', 'deletedAt'],
+      exclude: ['user_id', 'deletedAt'],
     },
     include: [
       {
@@ -70,6 +70,7 @@ export const searchAllCommentsByLessonId = async (
  * @param user_id user ID
  * @param lesson_id lesson ID
  * @param comment comment
+ * @param stars stars
  * @returns Promise<Comment>
  * @throws ErrorResponse if it fails to register to comment.
  * @author joohongpark
@@ -78,11 +79,13 @@ export const addComment = async (
   user_id: number,
   lesson_id: number,
   comment: string,
+  stars: number,
 ): Promise< Comment > => {
   const newComment: Comment = Comment.build({
     user_id,
     lesson_id,
     content: comment,
+    stars,
   });
   const rtn = newComment.save().catch(() => {
     throw new ErrorResponse(Status.BAD_REQUEST, '댓글 등록에 실패하였습니다.');
@@ -95,16 +98,19 @@ export const addComment = async (
  * 
  * @param comment_id comment ID
  * @param comment comment
+ * @param stars stars
  * @returns Promise< boolean >
  * @author joohongpark
  */
 export const updateComment = async (
   comment_id: number,
   comment: string,
+  stars: number,
 ): Promise< boolean > => {
   const rtn = await Comment.update(
     {
       content: comment,
+      stars,
     },
     {
       where: {

--- a/munetic_express/src/swagger/apis/comment.yml
+++ b/munetic_express/src/swagger/apis/comment.yml
@@ -96,16 +96,19 @@ paths:
           type: integer
           format: int32
           required: true
-        - name: comment
+        - name: 'comment, stars'
           in: body
-          description: 'new Comment'
+          description: 'new Comment and stars'
           schema:
             type: object
             required:
               - 'comment'
+              - 'stars'
             properties:
               comment:
                 type: string
+              stars:
+                type: integer
       responses:
         '200':
           description: 댓글 추가에 성공하였을 때
@@ -147,16 +150,19 @@ paths:
           type: integer
           format: int32
           required: true
-        - name: comment
+        - name: 'comment, stars'
           in: body
-          description: 'new Comment'
+          description: 'new Comment and stars'
           schema:
             type: object
             required:
               - 'comment'
+              - 'stars'
             properties:
               comment:
                 type: string
+              stars:
+                type: integer
       responses:
         '200':
           description: 댓글 업데이트에 성공하거나 존재하지 않는 댓글일 때

--- a/munetic_express/src/swagger/definitions.yml
+++ b/munetic_express/src/swagger/definitions.yml
@@ -309,6 +309,9 @@ definitions:
       content:
         description: 'comment'
         type: string
+      stars:
+        description: '별 개수'
+        type: integer
       updatedAt:
         description: 'The time when the Column was updated'
         type: string
@@ -334,6 +337,9 @@ definitions:
       content:
         description: '댓글 내용'
         type: string
+      stars:
+        description: '별 개수'
+        type: integer
       updatedAt:
         description: 'The time when the Column was updated'
         type: string


### PR DESCRIPTION
### 개요
#176 이슈에 대한 구현

### 작업 사항
### 프론트엔드
- 레슨 게시글 ID를 송신하고 댓글 목록 수신
- 댓글이 없을 경우 “댓글이 없습니다" 표시
- 댓글 목록 파싱하고 출력
- 정렬 옵션 (별점 높은 순 /별점 낮은 순) 버튼 구현
### 백엔드
- 레슨 게시글 ID에 따라 해당 게시글의 모든 댓글 반환(별점 높은 순)
- 레슨 게시글 ID에 따라 해당 게시글의 모든 댓글 반환(별점 낮은 순)

### 변경점
- 팔레트 파일에 red 컬러값 채도 변경

### 목적
- 요구사항에 맞는 구현을 위함

### 스크린샷 (optional)
