### PR TITLE
[feat] 좋아요 기능 구현 일부 완료

### DIFF
--- a/munetic_app/src/components/buttons/BookmarkButton.tsx
+++ b/munetic_app/src/components/buttons/BookmarkButton.tsx
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+import { Bookmark, BookmarkBorder } from '@mui/icons-material';
+import { IconButton } from '@mui/material';
+
+/**
+ * 북마크 버튼 컴포넌트입니다. 서버와의 비동기 통신으로 강의에 대한 북마크 여부 및 북마크 상태를 업데이트 합니다.
+ * 
+ * @returns 리액트 앨리먼트
+ * @author joohongpark
+ */
+export default function BookmarkButton() {
+  const [bookmark, setBookmark] = useState<boolean>(false);
+
+  return (
+    <IconButton color="inherit" onClick={() => setBookmark(!bookmark)}>
+      {bookmark ? <Bookmark /> : <BookmarkBorder />}
+    </IconButton>
+  );
+}

--- a/munetic_app/src/components/buttons/LikeButton.tsx
+++ b/munetic_app/src/components/buttons/LikeButton.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react';
+import { Favorite, FavoriteBorder } from '@mui/icons-material';
+import { IconButton } from '@mui/material';
+import * as LikeAPI from '../../lib/api/like';
+
+/**
+ * 서버와의 비동기 통신으로 좋아요 상태를 가져오는 함수입니다.
+ * 
+ * @param lesson_id number 강의 ID
+ * @returns boolean 좋아요/싫어요
+ * @author joohongpark
+ */
+async function getLessonLike(lesson_id: number): Promise<boolean> {
+  if (Number.isNaN(lesson_id))
+    return false;
+  try {
+    const res = await LikeAPI.getLessonLike(lesson_id);
+    return res.data.data;
+  } catch (e) {
+    console.log(e, '좋아요 정보를 가져오는 데 오류가 발생했습니다.');
+    return false;
+  }
+}
+
+/**
+ * 서버와의 비동기 통신으로 좋아요 상태를 반영하는 함수입니다.
+ * 
+ * @param lesson_id number 강의 ID
+ * @param liked boolean 좋아요/싫어요
+ * @returns boolean 반영 여부
+ * @author joohongpark
+ */
+async function ToggleLessonLike(lesson_id: number, liked: boolean): Promise<boolean> {
+  if (Number.isNaN(lesson_id))
+    return false;
+  try {
+    let result: any;
+    if (liked) {
+      result = await LikeAPI.delLessonLike(lesson_id);
+    } else {
+      result = await LikeAPI.putLessonLike(lesson_id);
+    }
+    return result.data.data;
+  } catch (e) {
+    console.log(e, '좋아요 정보를 가져오는 데 오류가 발생했습니다.');
+    return false;
+  }
+}
+
+/**
+ * 좋아요 버튼 컴포넌트입니다. 서버와의 비동기 통신으로 강의에 대한 좋아요 여부 및 좋아요 상태를 업데이트 합니다.
+ * 
+ * @param props.lesson_id 강의 ID
+ * @returns 리액트 앨리먼트
+ * @author joohongpark
+ */
+export default function LikeButton({lesson_id} : {lesson_id: number}) {
+  const [like, setLike] = useState<boolean>(false);
+
+  useEffect(() => {
+    getLessonLike(lesson_id).then(result => setLike(result));
+  }, [lesson_id]);
+
+  return (
+    <IconButton
+      color="inherit"
+      onClick={
+        () => ToggleLessonLike(lesson_id, like).then(
+          (result) => {
+            if (result) {
+              setLike(!like);
+            }
+          }
+        )
+      }>
+      {like ? <Favorite /> : <FavoriteBorder />}
+    </IconButton>
+  );
+}

--- a/munetic_app/src/components/lesson/Class.tsx
+++ b/munetic_app/src/components/lesson/Class.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import styled from 'styled-components';
-import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
-import BookmarkBorderIcon from '@mui/icons-material/BookmarkBorder';
 import InstagramIcon from '@mui/icons-material/Instagram';
 import YouTubeIcon from '@mui/icons-material/YouTube';
 import palette from '../../style/palette';
@@ -14,6 +12,8 @@ import { Gender } from '../../types/enums';
 import Comment from '../comment/Comment';
 import CommentTop from '../comment/CommentTop';
 import CommentWrite from '../comment/CommentWrite';
+import LikeButton from '../buttons/LikeButton';
+import BookmarkButton from '../buttons/BookmarkButton';
 
 const ClassContainer = styled.div`
   margin: 10px;
@@ -45,6 +45,9 @@ const ClassProfileWrapper = styled.div`
     flex-direction: column;
     justify-content: space-between;
     margin: 10px;
+  }
+  .snsTop {
+    color: ${palette.red};
   }
 `;
 
@@ -294,8 +297,8 @@ export default function Class() {
         </div>
         <div className="sns">
           <div className="snsTop">
-            <FavoriteBorderIcon />
-            <BookmarkBorderIcon />
+            <LikeButton lesson_id={Number(classId)} />
+            <BookmarkButton />
           </div>
           <div className="snsBottom">
             <InstagramIcon />

--- a/munetic_app/src/lib/api/like.ts
+++ b/munetic_app/src/lib/api/like.ts
@@ -1,0 +1,7 @@
+import client from './client';
+
+export const getLessonLikes = () => client.get(`/like`);
+export const getLessonLike = (lesson_id: number) => client.get(`/like/${lesson_id}`);
+export const getLikedPeoples = (lesson_id: number) => client.get(`/like/${lesson_id}/all`);
+export const putLessonLike = (lesson_id: number) => client.put(`/like/${lesson_id}`);
+export const delLessonLike = (lesson_id: number) => client.delete(`/like/${lesson_id}`);

--- a/munetic_express/src/controllers/lessonLike.controller.ts
+++ b/munetic_express/src/controllers/lessonLike.controller.ts
@@ -1,0 +1,142 @@
+import { RequestHandler } from 'express';
+import * as Status from 'http-status';
+import ErrorResponse from '../modules/errorResponse';
+import { ResJSON } from '../modules/types';
+import * as LessonLikeService from '../service/lessonLike.service';
+import { LessonLike } from '../models/lessonLike';
+
+/**
+ * 유저가 좋아요를 누른 강의들을 읽어오는 미들웨어
+ * 
+ * @param req request Objrct
+ * @param res response Objrct
+ * @param next next middleware function Object
+ * @author joohongpark
+ */
+export const getLessonLikes: RequestHandler = async (req, res, next) => {
+  try {
+    if (req.user) {
+      const likes = await LessonLikeService.searchAllLessonLikes(req.user.id);
+      const result: ResJSON = new ResJSON(
+        '좋아요 항목들을 불러오는데 성공하였습니다.',
+        likes,
+      );
+      res.status(Status.OK).json(result);
+    } else {
+      next(new ErrorResponse(Status.UNAUTHORIZED, '로그인이 필요합니다.'));
+    }
+  } catch (err) {
+    next(err);
+  }
+};
+
+/**
+ * 강의에 좋아요 누른 사람들을 가져오는 미들웨어
+ * 
+ * @param req request Objrct
+ * @param res response Objrct
+ * @param next next middleware function Object
+ * @author joohongpark
+ */
+export const getLikedPeoples: RequestHandler = async (req, res, next) => {
+  try {
+    if (req.user) {
+      const likes = await LessonLikeService.getLikedPeoples(parseInt(req.params.lesson_id, 10));
+      const result: ResJSON = new ResJSON(
+        '강의에 좋아요 누른 사람들을 불러오는데 성공하였습니다.',
+        likes,
+      );
+      res.status(Status.OK).json(result);
+    } else {
+      next(new ErrorResponse(Status.UNAUTHORIZED, '로그인이 필요합니다.'));
+    }
+  } catch (err) {
+    next(err);
+  }
+};
+
+/**
+ * 유저가 레슨(lesson_id)을 좋아요 눌렀는지의 여부를 읽어오는 미들웨어
+ * 
+ * @param req request Object
+ * @param res response Object
+ * @param next next middleware function Object
+ * @author joohongpark
+ */
+export const getLessonLike: RequestHandler = async (req, res, next) => {
+  try {
+    if (req.user) {
+      const likes = await LessonLikeService.searchLessonLike(
+        req.user.id,
+        parseInt(req.params.lesson_id, 10),
+      );
+      const result: ResJSON = new ResJSON(
+        '좋아요 여부를 확인하는데 성공하였습니다.',
+        likes,
+      );
+      res.status(Status.OK).json(result);
+    } else {
+      next(new ErrorResponse(Status.UNAUTHORIZED, '로그인이 필요합니다.'));
+    }
+  } catch (err) {
+    next(err);
+  }
+};
+
+/**
+ * 유저가 레슨(lesson_id)에 대해 좋아요를 설정하는 미들웨어
+ * 
+ * @param req request Objrct
+ * @param res response Objrct
+ * @param next next middleware function Object
+ * @author joohongpark
+ */
+export const putLessonLike: RequestHandler = async (req, res, next) => {
+  try {
+    if (req.user) {
+      const ok: boolean = await LessonLikeService.setLessonLike(
+        req.user.id,
+        parseInt(req.params.lesson_id, 10),
+        true,
+      );
+      const result: ResJSON = new ResJSON(
+        ok ? '좋아요 데이터를 저장하는데 성공하였습니다.' : '좋아요 데이터를 저장하는데 실패하였습니다.',
+        ok,
+      );
+      res.status(Status.CREATED).json(result);
+    } else {
+      next(new ErrorResponse(Status.UNAUTHORIZED, '로그인이 필요합니다.'));
+    }
+  } catch (err) {
+    next(err);
+  }
+};
+
+/**
+ * 유저가 레슨(lesson_id)에 대해 좋아요를 해제하는 미들웨어
+ * 
+ * @param req request Objrct
+ * @param res response Objrct
+ * @param next next middleware function Object
+ * @author joohongpark
+ */
+export const delLessonLike: RequestHandler = async (req, res, next) => {
+  try {
+      if (req.user) {
+        const ok: boolean = await LessonLikeService.setLessonLike(
+          req.user.id,
+          parseInt(req.params.lesson_id, 10),
+          false,
+        );
+        const result: ResJSON = new ResJSON(
+          ok ? '좋아요 데이터를 삭제하는데 성공하였습니다.' : '좋아요 데이터를 삭제하는데 실패하였습니다.',
+          ok,
+        );
+        res.status(Status.OK).json(result);
+      } else {
+        next(new ErrorResponse(Status.UNAUTHORIZED, '로그인이 필요합니다.'));
+      }
+    } catch (err) {
+      next(err);
+    }
+};

--- a/munetic_express/src/models/index.ts
+++ b/munetic_express/src/models/index.ts
@@ -5,6 +5,7 @@ import { Bookmark } from './bookmark';
 import { Comment } from './comment';
 import { User, Gender, Account } from './user';
 import * as UserService from '../service/user.service';
+import { LessonLike } from './lessonLike';
 
 const { development } = require('../config/config');
 const { host, port, database, username, password } = development;
@@ -39,6 +40,7 @@ export function Models() {
   Lesson.initModel(sequelize);
   Bookmark.initModel(sequelize);
   Comment.initModel(sequelize);
+  LessonLike.initModel(sequelize);
 
   Category.hasMany(Lesson, {
     foreignKey: {
@@ -74,6 +76,18 @@ export function Models() {
     foreignKey: 'lesson_id',
   });
   Bookmark.belongsTo(Lesson, {
+    foreignKey: 'lesson_id',
+  });
+  User.hasMany(LessonLike, {
+    foreignKey: 'user_id',
+  });
+  LessonLike.belongsTo(User, {
+    foreignKey: 'user_id',
+  });
+  Lesson.hasOne(LessonLike, {
+    foreignKey: 'lesson_id',
+  });
+  LessonLike.belongsTo(Lesson, {
     foreignKey: 'lesson_id',
   });
   User.hasMany(Comment, {

--- a/munetic_express/src/models/lessonLike.ts
+++ b/munetic_express/src/models/lessonLike.ts
@@ -1,0 +1,69 @@
+import { Sequelize, DataTypes, Model, Optional, HasOneGetAssociationMixin } from 'sequelize';
+import { Lesson } from './lesson';
+
+export interface lessonLikeAttributes {
+  id: number;
+  user_id: number;
+  lesson_id: number;
+  lesson_like: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date;
+}
+
+type lessonLikeCreationAttributes = Optional<lessonLikeAttributes,
+  'id' | 'createdAt' | 'updatedAt' | 'deletedAt'
+>;
+
+export class LessonLike
+  extends Model<lessonLikeAttributes, lessonLikeCreationAttributes>
+  implements lessonLikeAttributes
+{
+  public id!: number;
+  public user_id!: number;
+  public lesson_id!: number;
+  public lesson_like!: boolean;
+  public readonly createdAt!: Date;
+  public readonly updatedAt!: Date;
+  public readonly deletedAt!: Date;
+
+  declare getLesson: HasOneGetAssociationMixin<Lesson>;
+
+  static initModel(sequelize: Sequelize): typeof LessonLike {
+    return LessonLike.init(
+      {
+        id: {
+          allowNull: false,
+          autoIncrement: true,
+          type: DataTypes.INTEGER,
+          primaryKey: true,
+        },
+        user_id: {
+          allowNull: false,
+          type: DataTypes.INTEGER,
+        },
+        lesson_id: {
+          allowNull: false,
+          type: DataTypes.INTEGER,
+        },
+        lesson_like: {
+          allowNull: false,
+          type: DataTypes.BOOLEAN,
+        },
+        createdAt: {
+          field: 'createdAt',
+          type: DataTypes.DATE,
+        },
+        updatedAt: {
+          field: 'updatedAt',
+          type: DataTypes.DATE,
+        },
+        deletedAt: {
+          field: 'deletedAt',
+          type: DataTypes.DATE,
+        },
+      },
+      { tableName: 'LessonLike', sequelize },
+    );
+  }
+}

--- a/munetic_express/src/routes/index.ts
+++ b/munetic_express/src/routes/index.ts
@@ -9,6 +9,7 @@ import * as admin from './admin/admin.routes';
 import * as bookmark from './bookmark.routes';
 import * as comment from './comment.routes';
 import * as search from './search.routes';
+import * as lessonLike from './lessonLike.routes';
 
 import passport from 'passport';
 import AdminStrategy from '../modules/admin.strategy';
@@ -39,3 +40,4 @@ router.use(category.path, category.router);
 router.use(bookmark.path, bookmark.router);
 router.use(comment.path, comment.router);
 router.use(search.path, search.router);
+router.use(lessonLike.path, lessonLike.router);

--- a/munetic_express/src/routes/lessonLike.routes.ts
+++ b/munetic_express/src/routes/lessonLike.routes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import * as LessonLikeAPI from '../controllers/lessonLike.controller';
+import { jwtAuth } from '../modules/jwt.local.strategy';
+
+export const path = '/like';
+export const router = Router();
+
+router.get('/', jwtAuth(), LessonLikeAPI.getLessonLikes);
+router.get('/:lesson_id', jwtAuth(), LessonLikeAPI.getLessonLike);
+router.put('/:lesson_id', jwtAuth(), LessonLikeAPI.putLessonLike);
+router.delete('/:lesson_id', jwtAuth(), LessonLikeAPI.delLessonLike);
+router.get('/:lesson_id/all', jwtAuth(), LessonLikeAPI.getLikedPeoples);

--- a/munetic_express/src/service/bookmark.service.ts
+++ b/munetic_express/src/service/bookmark.service.ts
@@ -49,6 +49,10 @@ export const createBookmark = async (
   user_id: number,
   lesson_id: number,
 ): Promise< Bookmark > => {
+  const isExists = await searchBookmark(user_id, lesson_id);
+  if (isExists) {
+    throw new ErrorResponse(Status.BAD_REQUEST, '이미 북마크한 레슨입니다.');
+  }
   const newBookmark: Bookmark = Bookmark.build({
     user_id,
     lesson_id,
@@ -104,6 +108,6 @@ export const removeBookmark = async (
     }
   });
   if (!checkExistence) return false;
-  await checkExistence.destroy();
+  await checkExistence.destroy({force: true});
   return true;
 };

--- a/munetic_express/src/service/lessonLike.service.ts
+++ b/munetic_express/src/service/lessonLike.service.ts
@@ -1,0 +1,129 @@
+import { Op } from 'sequelize';
+import * as Status from 'http-status';
+import { LessonLike } from '../models/lessonLike';
+import ErrorResponse from '../modules/errorResponse';
+import { Lesson } from '../models/lesson';
+import { User } from '../models/user';
+
+/**
+ * user가 좋아요 한 모든 강의 조회
+ * 
+ * @param user_id user ID
+ * @returns Promise<LessonLike[]>
+ * @throws ErrorResponse if the user ID is not exists.
+ * @author joohongpark
+ */
+export const searchAllLessonLikes = async (
+  user_id: number,
+): Promise< LessonLike[] > => {
+  const searchLessonLikes = await LessonLike.findAll({
+    where: {
+      user_id,
+    },
+    include: [
+      {
+        model: Lesson,
+        attributes: {
+          exclude: ['id', 'createdAt', 'deletedAt'],
+        },
+      }
+    ],
+    attributes: {
+      exclude: ['user_id', 'createdAt', 'deletedAt'],
+    },
+  });
+  if (!searchLessonLikes)
+    throw new ErrorResponse(Status.BAD_REQUEST, '유효하지 않은 유저 id입니다.');
+  return searchLessonLikes;
+};
+
+/**
+ * 강의에 좋아요를 누른 사람들 목록 리턴
+ * 
+ * @param user_id user ID
+ * @returns Promise<LessonLike[]>
+ * @throws ErrorResponse if the user ID is not exists.
+ * @author joohongpark
+ */
+export const getLikedPeoples = async (
+  lesson_id: number,
+): Promise< LessonLike[] > => {
+  const searchLessonLikes = await LessonLike.findAll({
+    where: {
+      lesson_id,
+    },
+    include: [
+      {
+        model: User,
+        attributes: ['type', 'login_id', 'nickname'],
+      }
+    ],
+    attributes: [],
+  });
+  if (!searchLessonLikes)
+    throw new ErrorResponse(Status.BAD_REQUEST, '유효하지 않은 강의 id입니다.');
+  return searchLessonLikes;
+};
+
+/**
+ * user가 강의에 좋아요 눌렀는지 여부 확인
+ * 
+ * @param user_id user ID
+ * @param lesson_id lesson ID
+ * @returns Promise<boolean>
+ * @author joohongpark
+ */
+export const searchLessonLike = async (
+  user_id: number,
+  lesson_id: number,
+): Promise< boolean > => {
+  const checkExistence = await LessonLike.findOne({
+    where: {
+      [Op.and]: [
+        { user_id },
+        { lesson_id },
+        { lesson_like: true },
+      ]
+    },
+  });
+  if (!checkExistence) return false;
+  return true;
+};
+
+/**
+ * 강의에 대해 좋아요 체크 또는 해제
+ * 
+ * @param user_id user ID
+ * @param lesson_id lesson ID
+ * @param likes like / unlike
+ * @returns Promise<LessonLike>
+ * @throws ErrorResponse if the user ID or lesson ID is not exists.
+ * @author joohongpark
+ */
+export const setLessonLike = async (
+  user_id: number,
+  lesson_id: number,
+  likes: boolean,
+): Promise< boolean > => {
+  let rtn: boolean = false;
+  try {
+    const newLessonLike: [LessonLike, boolean] = await LessonLike.findOrCreate({
+      where: {
+        [Op.and]: [
+          { user_id },
+          { lesson_id },
+        ]
+      },
+      defaults: {
+        user_id,
+        lesson_id,
+        lesson_like: likes,
+      },
+    });
+    const check = await newLessonLike[0].update({ lesson_like: likes });
+    rtn = check !== null;
+  } catch (e) {
+    throw new ErrorResponse(Status.BAD_REQUEST, '유효하지 않은 강의 id입니다.');
+  }
+  return rtn;
+};

--- a/munetic_express/src/service/lessonLike.service.ts
+++ b/munetic_express/src/service/lessonLike.service.ts
@@ -18,7 +18,10 @@ export const searchAllLessonLikes = async (
 ): Promise< LessonLike[] > => {
   const searchLessonLikes = await LessonLike.findAll({
     where: {
-      user_id,
+      [Op.and]: [
+        { user_id },
+        { lesson_like: true },
+      ]
     },
     include: [
       {
@@ -50,7 +53,10 @@ export const getLikedPeoples = async (
 ): Promise< LessonLike[] > => {
   const searchLessonLikes = await LessonLike.findAll({
     where: {
-      lesson_id,
+      [Op.and]: [
+        { lesson_id },
+        { lesson_like: true },
+      ]
     },
     include: [
       {

--- a/munetic_express/src/swagger/apis/lesson_like.yml
+++ b/munetic_express/src/swagger/apis/lesson_like.yml
@@ -1,0 +1,184 @@
+swagger: '2.0'
+info:
+  title: API Title
+  version: '1.0'
+tags:
+  - name: LessonLike
+    description: '강의에 대해 좋아요 등록 및 해제 및 확인, 좋아요한 강의 및 강의에 좋아요 누른 사람 출력'
+paths:
+  /like/:
+    get:
+      tags:
+        - LessonLike
+      summary: '로그인한 유저가 좋아요 누른 항목 조회'
+      parameters:
+        - name: Authorization
+          in: header
+          type: string
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: '유저가 좋아요 누른 모든 레슨'
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: '북마크 데이터를 불러오는데 성공하였습니다.'
+              data:
+                type: array
+        '401':
+          description: 'Invalid JWT token'
+          schema:
+            type: string
+            example: Unauthorized
+  /like/{lesson_id}:
+    get:
+      tags:
+        - LessonLike
+      summary: '해당 레슨에 좋아요를 눌렀는지 확인'
+      produces:
+        - application/json
+      parameters:
+        - name: Authorization
+          in: header
+          type: string
+        - name: 'lesson_id'
+          in: path
+          description: 'lesson id'
+          type: integer
+          format: int32
+          required: true
+      responses:
+        '201':
+          description: 레슨 북마크에 성공하였을 때
+          schema:
+            required:
+              - message
+              - data
+            properties:
+              message:
+                type: string
+                example: '북마크 데이터를 저장하는데 성공하였습니다.'
+              data:
+                type: boolean
+        '401':
+          description: 'Invalid JWT token'
+          schema:
+            type: string
+            example: Unauthorized
+    put:
+      tags:
+        - LessonLike
+      summary: '해당 레슨 좋아요'
+      produces:
+        - application/json
+      parameters:
+        - name: Authorization
+          in: header
+          type: string
+        - name: 'lesson_id'
+          in: path
+          description: 'lesson id'
+          type: integer
+          format: int32
+          required: true
+      responses:
+        '200':
+          description: 좋아요 등록에 성공할 때
+          schema:
+            required:
+              - message
+              - data
+            properties:
+              message:
+                type: string
+                example: '좋아요 데이터를 저장하는데 성공하였습니다.'
+              data:
+                type: boolean
+                example: true
+        '400':
+          description: 레슨 ID가 존재하지 않을 때
+          schema:
+            type: string
+            example: '유효하지 않은 강의 id입니다.'
+        '401':
+          description: 'Invalid JWT token'
+          schema:
+            type: string
+            example: Unauthorized
+    delete:
+      tags:
+        - LessonLike
+      summary: '해당 레슨 좋아요 취소'
+      produces:
+        - application/json
+      parameters:
+        - name: Authorization
+          in: header
+          type: string
+        - name: 'lesson_id'
+          in: path
+          description: 'lesson id'
+          type: integer
+          format: int32
+          required: true
+      responses:
+        '200':
+          description: 북마크 삭제에 성공하였을 때
+          schema:
+            required:
+              - message
+              - data
+            properties:
+              message:
+                type: string
+                example: '좋아요 데이터를 삭제하는데 성공하였습니다.'
+              data:
+                type: boolean
+                example: true
+        '400':
+          description: 레슨 ID가 존재하지 않을 때
+          schema:
+            type: string
+            example: '유효하지 않은 강의 id입니다.'
+        '401':
+          description: 'Invalid JWT token'
+          schema:
+            type: string
+            example: Unauthorized
+  /like/{lesson_id}/all:
+    get:
+      tags:
+        - LessonLike
+      summary: '해당 레슨에 좋아요를 누른 모든 유저'
+      produces:
+        - application/json
+      parameters:
+        - name: Authorization
+          in: header
+          type: string
+        - name: 'lesson_id'
+          in: path
+          description: 'lesson id'
+          type: integer
+          format: int32
+          required: true
+      responses:
+        '201':
+          description: '불러오는데 성공할 때'
+          schema:
+            required:
+              - message
+              - data
+            properties:
+              message:
+                type: string
+                example: '강의에 좋아요 누른 사람들을 불러오는데 성공하였습니다.'
+              data:
+                type: boolean
+        '401':
+          description: 'Invalid JWT token'
+          schema:
+            type: array


### PR DESCRIPTION
### 개요
#180 이슈에 대한 일부 구현 완료

### 작업 사항
강의에 대해 좋아요를 누르는 기능 및 좋아요 내역 서버에 저장하도록 구현하였습니다.
개인 프로필에서 좋아요 한 강의를 확인하는 기능은 아직 반영하지 않았는데
#182 에서 구현된 강의 목록 컴포넌트를 재사용하기 위해서 선반영하기 위함입니다.
개인 프로필에 좋아요 한 강의를 출력하는 기능은 두 PR이 Merge되고 나서 반영하겠습니다.

### 변경점
강의에 좋아요, 북마크 버튼 활성화 (북마크 여부는 서버에 저장되지는 않음)
좋아요 누른 강의 서버에서 저장되도록 구축

### 목적
요구사항에 맞는 구현을 위함.

### 스크린샷 (optional)
<img width="560" alt="스크린샷 2022-02-11 오후 12 48 47" src="https://user-images.githubusercontent.com/27172454/153534794-609f1797-df22-4657-93d6-8457ca3fd8bc.png">
