### PR TITLE
[feat] #184 메인 페이지 개선

### DIFF
--- a/munetic_app/src/App.tsx
+++ b/munetic_app/src/App.tsx
@@ -4,7 +4,8 @@ import GlobalStyle from './style/GlobalStyle';
 
 function App() {
   return (
-    <div>
+    // FIXME: 임시로 글꼴 설정했는데 추후에 바꾸어야 할 듯 합니다. by joohongpark
+    <div style={{fontFamily: "font-family: Roboto, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif"}}>
       <GlobalStyle />
       <TopBar />
       <Routing />

--- a/munetic_app/src/components/Home.tsx
+++ b/munetic_app/src/components/Home.tsx
@@ -1,142 +1,25 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import styled from 'styled-components';
-import Button from './common/Button';
-import * as Auth from '../lib/api/auth';
-import client from '../lib/api/client';
+
 import BottomMenu from './common/BottomMenu';
-import palette from '../style/palette';
-
-const Container = styled.div`
-  width: 100%;
-  height: 100%;
-  border-radius: 40px;
-  .homeButtonWrapper {
-    display: flex;
-    align-items: center;
-    justify-content: space-evenly;
-  }
-  .homeFindButton {
-    width: 40%;
-    height: 40%;
-  }
-  .homeRegisterButton {
-    width: 40%;
-    height: 40%;
-  }
-`;
-
-const InitialPageContainer = styled.div`
-  height: 100vh;
-  width: 100vw;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background-color: ${palette.ivory};
-`;
-
-const InitialPageCard = styled.div`
-  width: 80%;
-  height: 80%;
-  padding: 4rem 0rem 3.5rem 0rem;
-  border-radius: 20px;
-  background-color: ${palette.grayBlue};
-`;
-
-const Logo = styled.h1`
-  text-align: center;
-  font-size: 3rem;
-  font-weight: 700;
-  margin-top: 20px;
-  color: ${palette.ivory};
-`;
-
-const Buttons = styled.div`
-  width: auto;
-  padding: 10rem 2rem 2.5rem 2rem;
-`;
-
-const CustomButton = styled(Button)`
-  display: block;
-  height: 40px;
-  color: ${palette.grayBlue};
-  background-color: ${palette.ivory};
-  margin-top: 20px;
-  margin-bottom: 20px;
-`;
+import LoggedIn from './home/LoggedIn';
+import LoggedOut from './home/LoggedOut';
 
 export default function Home() {
-  const [loggedUser, setLoggedUser] = useState(localStorage.getItem('user'));
-
-  const navigate = useNavigate();
-
-  const onClickLogin = () => {
-    navigate('/auth/login');
-  };
-
-  const onClickLogout = async () => {
-    try {
-      await Auth.logout();
-      try {
-        client.defaults.headers.common['Authorization'] = '';
-        localStorage.removeItem('user');
-      } catch (e) {
-        console.log(e, 'localStorage is not working');
-      }
-      setLoggedUser(localStorage.getItem('user'));
-    } catch (e) {
-      console.log(e, '로그아웃 실패');
-    }
-  };
-
-  const onClickSignup = () => {
-    navigate('/auth/register');
-  };
-  const onClickSignupTutor = () => {
-    navigate('/auth/register?tutor=tutor');
-  };
+  const loggedUser = localStorage.getItem('user');
+  // FIXME: 타입(선생인지 학생인지)도 로컬 저장소에 저장해야 할듯
 
   return (
     <>
-    {loggedUser ? 
-    (
-      <>
-      <Container>
-        <div className="homeButtonWrapper">
-          <div className="homeFindButton">
-            <Button to="/lesson/category">레슨 찾기</Button>
-          </div>
-          <div className="homeRegisterButton">
-            {loggedUser ? (
-              <Button to="/lesson/manage">레슨 등록</Button>
-            ) : (
-              <Button to="/auth/register?tutor=tutor">
-                레슨 등록(선생님 계정 필요)
-              </Button>
-            )}
-          </div>
-        </div>
-        <button onClick={onClickLogout}>로그아웃</button>
-        <button onClick={onClickSignupTutor}>튜터 회원가입</button>
-      </Container>
-      <BottomMenu />
-      </>
-    ) : (
-      <InitialPageContainer>
-        <InitialPageCard>
-          <div>
-            <Logo>
-              <span>MUNETIC</span>
-            </Logo>
-            <Buttons>
-              <CustomButton onClick={onClickLogin}>로그인</CustomButton>
-              <CustomButton onClick={onClickSignup}>회원가입</CustomButton>
-            </Buttons>
-          </div>
-        </InitialPageCard>
-      </InitialPageContainer>
-    )
-    }
+      {loggedUser ? 
+        (
+          <>
+          <LoggedIn type={"student"} />
+          <BottomMenu />
+          </>
+        ) : (
+          <LoggedOut />
+        )
+      }
     </>
   );
 }

--- a/munetic_app/src/components/home/LoggedIn.tsx
+++ b/munetic_app/src/components/home/LoggedIn.tsx
@@ -1,0 +1,47 @@
+import styled from 'styled-components';
+import Button from '../common/Button';
+import BestPlayingVideo from '../media/BestPlayingVideo';
+import ViewTutorsProfile from '../profile/ViewTutorsProfile';
+
+
+const Container = styled.div`
+  padding: 20px;
+  width: 100%;
+  height: 100%;
+  border-radius: 40px;
+`;
+
+const ButtonsWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-evenly;
+`;
+
+const ButtonWrapper = styled.div`
+  width: 40%;
+  height: 40%;
+`;
+
+export default function LoggedIn({type}: {type: string}) {
+  return (
+    <Container>
+      <ButtonsWrapper>
+        <ButtonWrapper>
+          <Button to="/lesson/category">레슨 찾기</Button>
+        </ButtonWrapper>
+        <ButtonWrapper>
+          { type !== "student" ? (
+                <Button to="/lesson/manage">레슨 등록</Button>
+            ) : (
+              <Button to="/auth/register?tutor=tutor">
+                레슨 등록<br />(선생님 계정 필요)
+              </Button>
+            )
+          }
+        </ButtonWrapper>
+      </ButtonsWrapper>
+      <ViewTutorsProfile />
+      <BestPlayingVideo />
+    </Container>
+  );
+}

--- a/munetic_app/src/components/home/LoggedOut.tsx
+++ b/munetic_app/src/components/home/LoggedOut.tsx
@@ -1,0 +1,60 @@
+import styled from 'styled-components';
+import palette from '../../style/palette';
+import Button from '../common/Button';
+
+const InitialPageContainer = styled.div`
+height: 100vh;
+width: 100vw;
+display: flex;
+align-items: center;
+justify-content: center;
+background-color: ${palette.ivory};
+`;
+
+const InitialPageCard = styled.div`
+width: 80%;
+height: 80%;
+padding: 4rem 0rem 3.5rem 0rem;
+border-radius: 20px;
+background-color: ${palette.grayBlue};
+`;
+
+const Logo = styled.h1`
+text-align: center;
+font-size: 3rem;
+font-weight: 700;
+margin-top: 20px;
+color: ${palette.ivory};
+`;
+
+const Buttons = styled.div`
+width: auto;
+padding: 10rem 2rem 2.5rem 2rem;
+`;
+
+const CustomButton = styled(Button)`
+display: block;
+height: 40px;
+color: ${palette.grayBlue};
+background-color: ${palette.ivory};
+margin-top: 20px;
+margin-bottom: 20px;
+`;
+
+export default function LoggedOut() {
+  return (
+    <InitialPageContainer>
+      <InitialPageCard>
+        <div>
+          <Logo>
+            <span>MUNETIC</span>
+          </Logo>
+          <Buttons>
+            <CustomButton to='/auth/login'>로그인</CustomButton>
+            <CustomButton to='/auth/register'>회원가입</CustomButton>
+          </Buttons>
+        </div>
+      </InitialPageCard>
+    </InitialPageContainer>
+  );
+}

--- a/munetic_app/src/components/media/BestPlayingVideo.tsx
+++ b/munetic_app/src/components/media/BestPlayingVideo.tsx
@@ -1,0 +1,48 @@
+import styled from 'styled-components';
+
+const VideoWrapper = styled.div`
+  border-radius: 40px;
+  padding: 20px;
+  width: 100%;
+  height: 100%;
+  border: 1px solid #ccc;
+  border-radius: 5px;
+`;
+
+const VideoContainer = styled.div`
+  position: relative;
+  padding-bottom: 56.25%;
+  padding-top: 30px;
+  height: 0;
+  overflow: hidden;
+`;
+
+const Video = styled.iframe`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`;
+
+const Label = styled.div`
+  font-family: "Roboto","Arial",sans-serif;
+  font-size: 1.6rem;
+  line-height: 2.2rem;
+  font-weight: 400;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+`;
+
+export default function BestPlayingVideo() {
+  return (
+    <VideoWrapper>
+      <Label>베스트 연주 영상</Label>
+      <VideoContainer>
+        <Video src={"https://www.youtube.com/embed/ldxVFDvWCgg"} />
+      </VideoContainer>
+    </VideoWrapper>
+  );
+}

--- a/munetic_app/src/components/profile/ManageProfile.tsx
+++ b/munetic_app/src/components/profile/ManageProfile.tsx
@@ -7,6 +7,7 @@ import { UserDataType } from '../../types/userData';
 import * as ProfileAPI from '../../lib/api/profile';
 import Button from '../common/Button';
 import { Link, useNavigate } from 'react-router-dom';
+import logout from '../../lib/auth/logout';
 
 const Container = styled.div`
   margin: 30px 0;
@@ -39,7 +40,7 @@ const ProfileWrapper = styled.div`
     flex-direction: column;
     justify-content: space-between;
     align-items: center;
-    margin: 10px;
+    margin: 15px;
   }
 `;
 
@@ -93,6 +94,11 @@ export default function ManageProfile() {
     getMyProfile();
   }, []);
 
+  const onClickLogout = async () => {
+    logout();
+    navigate('/');
+  };
+
   return (
     <div>
       {!userData ? (
@@ -120,10 +126,9 @@ export default function ManageProfile() {
               <StyledEditButton to={`/profile/comment/${userData.login_id}`}>
                 작성한 댓글
               </StyledEditButton>
-              <div className="snsBottom">
-                <InstagramIcon />
-                <YouTubeIcon />
-              </div>
+              <StyledEditButton onClick={onClickLogout}>
+                로그아웃
+              </StyledEditButton>
             </div>
           </ProfileWrapper>
           <Separater />

--- a/munetic_app/src/components/profile/ViewTutorsProfile.tsx
+++ b/munetic_app/src/components/profile/ViewTutorsProfile.tsx
@@ -1,0 +1,83 @@
+import styled from 'styled-components';
+
+
+import ImageList from "@mui/material/ImageList";
+import ImageListItem from "@mui/material/ImageListItem";
+import ImageListItemBar from "@mui/material/ImageListItemBar";
+import Avatar from '@mui/material/Avatar';
+import Badge from '@mui/material/Badge';
+
+const TutorsWrapper = styled.div`
+  margin: 20px 0;
+  padding: 20px;
+  width: 100%;
+  height: 100%;
+  border-radius: 40px;
+`;
+
+const ImagesWrapper = styled.div`
+  margin-top: 20px;
+  padding: 0;
+  border: 0;
+`;
+
+const Label = styled.div`
+  font-family: "Roboto","Arial",sans-serif;
+  font-size: 1.6rem;
+  line-height: 2.2rem;
+  font-weight: 400;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+`;
+
+const favTutors = [
+  { tutor_id: 1, image_uri: "/img/basicProfileImg.png", tutor_name: "베토벤", reviews: 98},
+  { tutor_id: 2, image_uri: "/img/basicProfileImg.png", tutor_name: "모짜르트", reviews: 70},
+  { tutor_id: 3, image_uri: "/img/basicProfileImg.png", tutor_name: "쇼팽", reviews: 40},
+  { tutor_id: 4, image_uri: "/img/basicProfileImg.png", tutor_name: "바흐", reviews: 30},
+  { tutor_id: 5, image_uri: "/img/basicProfileImg.png", tutor_name: "쇼팽", reviews: 20},
+  { tutor_id: 6, image_uri: "/img/basicProfileImg.png", tutor_name: "루피", reviews: 10},
+  { tutor_id: 7, image_uri: "/img/basicProfileImg.png", tutor_name: "에스파", reviews: 9},
+  { tutor_id: 8, image_uri: "/img/basicProfileImg.png", tutor_name: "키츠요지", reviews: 8},
+  { tutor_id: 9, image_uri: "/img/basicProfileImg.png", tutor_name: "다이나믹듀오", reviews: 7},
+  { tutor_id: 10, image_uri: "/img/basicProfileImg.png", tutor_name: "피타입", reviews: 6},
+  { tutor_id: 11, image_uri: "/img/basicProfileImg.png", tutor_name: "Lil Mosey", reviews: 5},
+  { tutor_id: 12, image_uri: "/img/basicProfileImg.png", tutor_name: "Drake", reviews: 4},
+  { tutor_id: 13, image_uri: "/img/basicProfileImg.png", tutor_name: "Alexander O'Neal", reviews: 3},
+  { tutor_id: 14, image_uri: "/img/basicProfileImg.png", tutor_name: "Aron Afshar", reviews: 2},
+];
+
+
+export default function ViewTutorsProfile() {
+  return (
+    <TutorsWrapper>
+      <Label>리뷰 많은 강사 (상위 20명)</Label>
+      <ImagesWrapper>
+        <ImageList
+          rowHeight={200}
+          sx={{
+            gridAutoFlow: "column",
+            gridTemplateColumns: "repeat(auto-fit, minmax(160px,1fr)) !important",
+            gridAutoColumns: "minmax(160px, 1fr)"
+          }}
+        >
+        {favTutors.map((tutor) => (
+          <ImageListItem>
+            <Badge
+              overlap="circular"
+              anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+              badgeContent={
+                (<Badge badgeContent={tutor.reviews} color="secondary" />)
+              }>
+              <Avatar src={tutor.image_uri} sx={{ width: 150, height: 150 }} />
+            </Badge>
+            <ImageListItemBar title={tutor.tutor_name} />
+          </ImageListItem>
+        ))}
+        </ImageList>
+      </ImagesWrapper>
+    </TutorsWrapper>
+  );
+}

--- a/munetic_app/src/lib/auth/logout.ts
+++ b/munetic_app/src/lib/auth/logout.ts
@@ -1,0 +1,13 @@
+import * as Auth from '../api/auth';
+import client from '../api/client';
+
+export default async function Logout () {
+  try {
+    localStorage.removeItem('user');
+    await Auth.logout();
+    client.defaults.headers.common['Authorization'] = '';
+  } catch (e) {
+    alert("오류로 로그아웃에 실패하였습니다.");
+    console.log(e, '로그아웃 실패');
+  }
+};


### PR DESCRIPTION
### 개요
뮤네틱 앱의 메인 페이지 개선

### 작업 사항
- 메인 페이지의 리뷰 많은 강사 요소 목업 제작
- 메인 페이지의 베스트 연주 영상 요소 목업 제작

### 변경점
- 불필요한 버튼 제거
- 로그아웃 버튼 프로필 페이지로 이동
-  Home.tsx 기능 분할

### 목적
요구사항에 맞는 구현을 위함

### 스크린샷 (optional)
<img width="568" alt="스크린샷 2022-02-11 오후 5 04 23" src="https://user-images.githubusercontent.com/27172454/153556507-307c0d48-5076-4769-91e9-8cc03a097035.png">

